### PR TITLE
Create service params fix

### DIFF
--- a/src/controllers/services.js
+++ b/src/controllers/services.js
@@ -21,7 +21,7 @@ export default {
         throw new NotFoundError('Taxonomy not found');
       }
 
-      const createdService = await createService({ ...otherProps, location, taxonomy }, req.user);
+      const createdService = await createService(location, { ...otherProps, taxonomy }, req.user);
       res.status(201).send(createdService);
     } catch (err) {
       next(err);


### PR DESCRIPTION
### Description
This PR updates the params passed into the `createService` method which was causing a bug in the `/services` endpoint. The method signature is: 
```js
export const createService = async (location, serviceData, user) => ...
```