### PR TITLE
feature: support last update times for services

### DIFF
--- a/src/models/language.js
+++ b/src/models/language.js
@@ -13,8 +13,8 @@ module.exports = (sequelize, DataTypes) => {
   });
 
   Language.associate = (models) => {
-    Language.belongsToMany(models.Location, { through: 'location_languages' });
-    Language.belongsToMany(models.Service, { through: 'service_languages' });
+    Language.belongsToMany(models.Location, { through: models.LocationLanguages });
+    Language.belongsToMany(models.Service, { through: models.ServiceLanguages });
   };
 
   return Language;

--- a/src/models/location-languages.js
+++ b/src/models/location-languages.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const LocationLanguages = sequelize.define('LocationLanguages', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+  }, {
+    underscored: true,
+    underscoredAll: true,
+  });
+
+  return LocationLanguages;
+};

--- a/src/models/location.js
+++ b/src/models/location.js
@@ -17,7 +17,7 @@ module.exports = (sequelize, DataTypes) => {
   Location.associate = (models) => {
     Location.belongsTo(models.Organization);
     Location.belongsToMany(models.Service, { through: models.ServiceAtLocation });
-    Location.belongsToMany(models.Language, { through: 'location_languages' });
+    Location.belongsToMany(models.Language, { through: models.LocationLanguages });
     Location.hasMany(models.PhysicalAddress);
     Location.hasMany(models.Phone);
     Location.hasMany(models.RegularSchedule);

--- a/src/models/metadata.js
+++ b/src/models/metadata.js
@@ -69,15 +69,15 @@ module.exports = (sequelize, DataTypes) => {
     group: 'field_name',
   });
 
-  Metadata.getLatestUpdateDateForResource = resourceId => Metadata.max(
-    'last_action_date',
-    { where: { resource_id: resourceId } },
-  );
+  Metadata.getLatestUpdateDateForQuery = where => Metadata.max('last_action_date', { where });
 
-  Metadata.getLatestUpdateDateForResources = resourceIds => Metadata.max(
-    'last_action_date',
-    { where: { resource_id: { [sequelize.Op.in]: resourceIds } } },
-  );
+  Metadata.getLatestUpdateDateForResource = resourceId => Metadata.getLatestUpdateDateForQuery({
+    resource_id: resourceId,
+  });
+
+  Metadata.getLatestUpdateDateForResources = resourceIds => Metadata.getLatestUpdateDateForQuery({
+    resource_id: { [sequelize.Op.in]: resourceIds },
+  });
 
   return Metadata;
 };

--- a/src/models/service-languages.js
+++ b/src/models/service-languages.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const ServiceLanguages = sequelize.define('ServiceLanguages', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+  }, {
+    underscored: true,
+    underscoredAll: true,
+  });
+
+  return ServiceLanguages;
+};

--- a/src/models/service.js
+++ b/src/models/service.js
@@ -26,7 +26,7 @@ module.exports = (sequelize, DataTypes) => {
     });
     Service.belongsToMany(models.Location, { through: models.ServiceAtLocation });
     Service.belongsToMany(models.Taxonomy, { through: models.ServiceTaxonomy });
-    Service.belongsToMany(models.Language, { through: 'service_languages' });
+    Service.belongsToMany(models.Language, { through: models.ServiceLanguages });
     Service.hasMany(models.Phone);
     Service.hasMany(models.PaymentAccepted);
     Service.hasMany(models.RegularSchedule);

--- a/src/services/last-updates.js
+++ b/src/services/last-updates.js
@@ -1,0 +1,67 @@
+import models from '../models';
+
+export const getMetadataForLocation = async (location, address) => {
+  const [
+    locationMetadata,
+    organizationMetadata,
+    addressMetadata,
+    phonesLatestUpdate,
+  ] = await Promise.all([
+    models.Metadata.getLastUpdateDatesForResourceFields(location.id),
+    models.Metadata.getLastUpdateDatesForResourceFields(location.organization_id),
+    models.Metadata.getLastUpdateDatesForResourceFields(address.id),
+    models.Metadata.getLatestUpdateDateForResources(location.Phones.map(phone => phone.id)),
+  ]);
+
+  const locationWithPhonesMetadata = phonesLatestUpdate ? [
+    ...locationMetadata,
+    { field_name: 'phones', last_action_date: phonesLatestUpdate },
+  ] : locationMetadata;
+
+  return {
+    location: locationWithPhonesMetadata,
+    organization: organizationMetadata,
+    address: addressMetadata,
+  };
+};
+
+export const getMetadataForService = async (service) => {
+  const [
+    serviceMetadata,
+    hoursLatestUpdate,
+    languagesLatestUpdate,
+  ] = await Promise.all([
+    models.Metadata.getLastUpdateDatesForResourceFields(service.id),
+    models.Metadata.getLatestUpdateDateForQuery({
+      resource_table: 'regular_schedules',
+      field_name: 'service_id',
+      replacement_value: service.id,
+    }),
+    models.Metadata.getLatestUpdateDateForQuery({
+      resource_table: 'service_languages',
+      field_name: 'service_id',
+      replacement_value: service.id,
+    }),
+  ]);
+
+  const serviceWithAdditionalMetadata = [...serviceMetadata];
+  if (hoursLatestUpdate) {
+    serviceWithAdditionalMetadata.push({
+      field_name: 'hours',
+      last_action_date: hoursLatestUpdate,
+    });
+  }
+  if (languagesLatestUpdate) {
+    serviceWithAdditionalMetadata.push({
+      field_name: 'languages',
+      last_action_date: languagesLatestUpdate,
+    });
+  }
+
+  return { service: serviceWithAdditionalMetadata };
+};
+
+export default {
+  getMetadataForLocation,
+  getMetadataForService,
+};

--- a/test/integration/__snapshots__/get-location-info.test.js.snap
+++ b/test/integration/__snapshots__/get-location-info.test.js.snap
@@ -41,6 +41,9 @@ Object {
       "email": null,
       "fees": null,
       "interpretation_services": null,
+      "metadata": Object {
+        "service": Object {},
+      },
       "name": "A specific offering",
       "url": null,
     },


### PR DESCRIPTION
- Add last update metadata to all the Services returned
  when getting location info.
- Actually track metadata for changes to service hours/languages
  (generally service associations).
- Split getting last updates into a separate service.