### PR TITLE
feature: update location search per UX specs

### DIFF
--- a/src/models/location.js
+++ b/src/models/location.js
@@ -61,8 +61,8 @@ module.exports = (sequelize, DataTypes) => {
     if (searchString) {
       const fuzzySearchString = `%${searchString}%`;
       conditions.push(sequelize.or(
-        { name: { [sequelize.Op.iLike]: fuzzySearchString } },
         { '$Organization.name$': { [sequelize.Op.iLike]: fuzzySearchString } },
+        { '$Organization.description$': { [sequelize.Op.iLike]: fuzzySearchString } },
         { '$Services.name$': { [sequelize.Op.iLike]: fuzzySearchString } },
         { '$Services.Taxonomies.name$': { [sequelize.Op.iLike]: fuzzySearchString } },
       ));
@@ -83,6 +83,7 @@ module.exports = (sequelize, DataTypes) => {
           include: sequelize.models.Taxonomy,
         },
       ],
+      order: [[distance, 'ASC']],
     });
   };
 

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -160,17 +160,17 @@ describe('find locations', () => {
           searchString,
         });
 
-    it('should match locations that have the given string in their name', () =>
-      makeRequestWithSearchString('center')
-        .expect(200)
-        .then(expectMatchNearbyLocation));
-
     it('should match locations whose organization has the given string in its name', () =>
       makeRequestWithSearchString('test org')
         .expect(200)
         .then(expectMatchNearbyLocation));
 
-    it('should match locations who belong to a taxonomy containing the given string', () =>
+    it('should match locations whose organization has the given string in its description', () =>
+      makeRequestWithSearchString('testing purpose')
+        .expect(200)
+        .then(expectMatchNearbyLocation));
+
+    it('should match locations which belong to a taxonomy containing the given string', () =>
       makeRequestWithSearchString('shelter')
         .expect(200)
         .then(expectMatchNearbyLocation));
@@ -182,6 +182,11 @@ describe('find locations', () => {
 
     it('should not match if none of the relevant fields include the given string', () =>
       makeRequestWithSearchString('not matching')
+        .expect(200)
+        .then(expectNoMatchingLocations));
+
+    it('should not match locations that have the given string in their name', () =>
+      makeRequestWithSearchString('center')
         .expect(200)
         .then(expectNoMatchingLocations));
   });


### PR DESCRIPTION
- For the fields where the search string can be found,
  include organization description and exclude location name.
- Sort returned locations by distance to the given position.