### PR TITLE
Feature/metadata sources

### DIFF
--- a/sequelize/migrations/20200514165900-add-metadata-source-column.js
+++ b/sequelize/migrations/20200514165900-add-metadata-source-column.js
@@ -1,0 +1,9 @@
+export default {
+  up: (queryInterface, Sequelize) => Promise.all([
+    queryInterface.addColumn('metadata', 'source', Sequelize.TEXT),
+  ]),
+
+  down: (queryInterface, Sequelize) => Promise.all([
+    queryInterface.removeColumn('metadata', 'source'),
+  ]),
+};

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -191,6 +191,7 @@ export default {
         organizationId,
         address,
         additionalInfo,
+        metadata,
       } = req.body;
       const position = geometry.createPoint(longitude, latitude);
 
@@ -215,7 +216,7 @@ export default {
         state_province: address.state,
         postal_code: address.postalCode,
         country: address.country,
-      });
+      }, { metadata });
 
       res.status(201).send(createdLocation);
     } catch (err) {
@@ -224,7 +225,7 @@ export default {
   },
 
   update: async (req, res, next) => {
-    const updateLocation = (location, updateParams) => {
+    const updateLocation = (location, updateParams, metadata) => {
       const locationUpdate = {};
       if (updateParams.name != null) { locationUpdate.name = updateParams.name; }
       if (updateParams.description != null) {
@@ -241,10 +242,10 @@ export default {
         locationUpdate.organization_id = updateParams.organizationId;
       }
 
-      return updateInstance(req.user, location, locationUpdate);
+      return updateInstance(req.user, location, locationUpdate, { metadata });
     };
 
-    const updateAddress = (location, updateParams) => {
+    const updateAddress = (location, updateParams, metadata) => {
       if (!location.PhysicalAddresses || location.PhysicalAddresses.length !== 1) {
         throw new Error('Trying to update address for location with no valid existing address');
       }
@@ -259,10 +260,10 @@ export default {
       if (updateParams.postalCode != null) { addressUpdate.postal_code = updateParams.postalCode; }
       if (updateParams.country != null) { addressUpdate.country = updateParams.country; }
 
-      return updateInstance(req.user, currentAddress, addressUpdate);
+      return updateInstance(req.user, currentAddress, addressUpdate, { metadata });
     };
 
-    const updateEventRelatedInfo = async (location, eventRelatedInfo) => {
+    const updateEventRelatedInfo = async (location, eventRelatedInfo, metadata) => {
       await models.EventRelatedInfo.destroy({
         where: { location_id: location.id, event: eventRelatedInfo.event },
       });
@@ -273,7 +274,7 @@ export default {
           location_id: location.id,
           event: eventRelatedInfo.event,
           information: eventRelatedInfo.information,
-        });
+        }, { metadata });
       }
     };
 
@@ -281,6 +282,7 @@ export default {
       await Joi.validate(req, locationSchemas.update, { allowUnknown: true });
 
       const { locationId } = req.params;
+      const { metadata } = req.body;
 
       const location = await models.Location.findById(locationId, {
         include: models.PhysicalAddress,
@@ -293,14 +295,14 @@ export default {
       const updatePromises = [];
 
       if (req.body.address) {
-        updatePromises.push(updateAddress(location, req.body.address));
+        updatePromises.push(updateAddress(location, req.body.address, metadata));
       }
 
       if (req.body.eventRelatedInfo) {
-        updatePromises.push(updateEventRelatedInfo(location, req.body.eventRelatedInfo));
+        updatePromises.push(updateEventRelatedInfo(location, req.body.eventRelatedInfo, metadata));
       }
 
-      updatePromises.push(updateLocation(location, req.body));
+      updatePromises.push(updateLocation(location, req.body, metadata));
 
       await Promise.all(updatePromises);
 
@@ -327,6 +329,7 @@ export default {
         type,
         language,
         description,
+        metadata,
       } = req.body;
 
       const createdPhone = await createInstance(req.user, location.createPhone.bind(location), {
@@ -335,7 +338,7 @@ export default {
         type,
         language,
         description,
-      });
+      }, { metadata });
 
       res.status(201).send(createdPhone);
     } catch (err) {
@@ -355,7 +358,8 @@ export default {
       }
 
       const editableFields = ['number', 'extension', 'type', 'language', 'description'];
-      await updateInstance(req.user, phone, req.body, { fields: editableFields });
+      const { metadata, ...updateParams } = req.body;
+      await updateInstance(req.user, phone, updateParams, { fields: editableFields }, { metadata });
 
       res.sendStatus(204);
     } catch (err) {

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -206,7 +206,7 @@ export default {
         description,
         position,
         additional_info: additionalInfo,
-      });
+      }, { metadata });
 
       const addressCreateFunction = createdLocation.createPhysicalAddress.bind(createdLocation);
       await createInstance(req.user, addressCreateFunction, {
@@ -359,7 +359,7 @@ export default {
 
       const editableFields = ['number', 'extension', 'type', 'language', 'description'];
       const { metadata, ...updateParams } = req.body;
-      await updateInstance(req.user, phone, updateParams, { fields: editableFields }, { metadata });
+      await updateInstance(req.user, phone, updateParams, { fields: editableFields, metadata });
 
       res.sendStatus(204);
     } catch (err) {

--- a/src/controllers/organizations.js
+++ b/src/controllers/organizations.js
@@ -23,14 +23,19 @@ export default {
     try {
       await Joi.validate(req, organizationSchemas.create, { allowUnknown: true });
 
-      const { name, description, url } = req.body;
+      const {
+        name,
+        description,
+        url,
+        metadata,
+      } = req.body;
 
       const modelCreateFunction = models.Organization.create.bind(models.Organization);
       const createdOrganization = await createInstance(req.user, modelCreateFunction, {
         name,
         description,
         url,
-      });
+      }, { metadata });
 
       res.status(201).send(createdOrganization);
     } catch (err) {
@@ -50,8 +55,14 @@ export default {
       }
 
       const editableFields = ['name', 'description', 'url'];
+      const { metadata, ...updateParams } = req.body;
+      await updateInstance(
+        req.user,
+        organization,
+        updateParams,
+        { fields: editableFields, metadata },
+      );
 
-      await updateInstance(req.user, organization, req.body, { fields: editableFields });
       res.sendStatus(204);
     } catch (err) {
       next(err);

--- a/src/controllers/services.js
+++ b/src/controllers/services.js
@@ -9,7 +9,12 @@ export default {
     try {
       await Joi.validate(req, serviceSchemas.create, { allowUnknown: true });
 
-      const { taxonomyId, locationId, ...otherProps } = req.body;
+      const {
+        metadata,
+        taxonomyId,
+        locationId,
+        ...otherProps
+      } = req.body;
 
       const location = await models.Location.findById(locationId);
       if (!location) {
@@ -21,7 +26,12 @@ export default {
         throw new NotFoundError('Taxonomy not found');
       }
 
-      const createdService = await createService(location, { ...otherProps, taxonomy }, req.user);
+      const createdService = await createService(
+        location,
+        { ...otherProps, taxonomy },
+        req.user,
+        metadata,
+      );
       res.status(201).send(createdService);
     } catch (err) {
       next(err);
@@ -33,7 +43,7 @@ export default {
       await Joi.validate(req, serviceSchemas.update, { allowUnknown: true });
 
       const { serviceId } = req.params;
-      const { taxonomyId, ...otherProps } = req.body;
+      const { metadata, taxonomyId, ...otherProps } = req.body;
 
       const service = await models.Service.findById(serviceId, {
         include: [models.DocumentsInfo],
@@ -53,7 +63,7 @@ export default {
         }
       }
 
-      await updateService(service, { ...otherProps, taxonomy }, req.user);
+      await updateService(service, { ...otherProps, taxonomy }, req.user, metadata);
       res.sendStatus(204);
     } catch (err) {
       next(err);

--- a/src/controllers/validation/locations.js
+++ b/src/controllers/validation/locations.js
@@ -1,5 +1,10 @@
 import Joi from 'joi';
 
+const updateMetadataSchema = Joi.object().keys({
+  source: Joi.string(),
+  lastUpdated: Joi.date().iso(),
+});
+
 export default {
   find: {
     query: Joi.object().keys({
@@ -52,6 +57,7 @@ export default {
         postalCode: Joi.string().required(),
         country: Joi.string().required(),
       }).required(),
+      metadata: updateMetadataSchema,
     }).required(),
   },
 
@@ -78,6 +84,7 @@ export default {
         event: Joi.string().required(),
         information: Joi.string().required().allow(null),
       }),
+      metadata: updateMetadataSchema,
     }).required(),
   },
 
@@ -91,6 +98,7 @@ export default {
       type: Joi.string(),
       language: Joi.string(),
       description: Joi.string(),
+      metadata: updateMetadataSchema,
     }).required(),
   },
 
@@ -104,6 +112,7 @@ export default {
       type: Joi.string(),
       language: Joi.string(),
       description: Joi.string(),
+      metadata: updateMetadataSchema,
     }),
   },
 

--- a/src/controllers/validation/organizations.js
+++ b/src/controllers/validation/organizations.js
@@ -1,5 +1,10 @@
 import Joi from 'joi';
 
+const updateMetadataSchema = Joi.object().keys({
+  source: Joi.string(),
+  lastUpdated: Joi.date().iso(),
+});
+
 export default {
   find: {
     query: Joi.object().keys({
@@ -12,6 +17,7 @@ export default {
       name: Joi.string().required(),
       description: Joi.string(),
       url: Joi.string(),
+      metadata: updateMetadataSchema,
     }).required(),
   },
 
@@ -23,6 +29,7 @@ export default {
       name: Joi.string(),
       description: Joi.string(),
       url: Joi.string(),
+      metadata: updateMetadataSchema,
     }).required(),
   },
 

--- a/src/controllers/validation/services.js
+++ b/src/controllers/validation/services.js
@@ -12,6 +12,11 @@ const weekdays = [
 
 const hourRegex = /^\d{2}:\d{2}$/;
 
+const updateMetadataSchema = Joi.object().keys({
+  source: Joi.string(),
+  lastUpdated: Joi.date().iso(),
+});
+
 export default {
   create: {
     body: Joi.object().keys({
@@ -21,6 +26,7 @@ export default {
       additionalInfo: Joi.string(),
       taxonomyId: Joi.string().guid().required(),
       locationId: Joi.string().guid().required(),
+      metadata: updateMetadataSchema,
     }).required(),
   },
 
@@ -68,6 +74,7 @@ export default {
       }),
       agesServed: Joi.any(),
       whoDoesItServe: Joi.any(),
+      metadata: updateMetadataSchema,
     }).required(),
   },
 };

--- a/src/middleware/data-entry-auth.js
+++ b/src/middleware/data-entry-auth.js
@@ -1,0 +1,14 @@
+import { ForbiddenError } from '../utils/errors';
+
+export default function dataEntryAuth(req, res, next) {
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+    next();
+    return;
+  }
+
+  if (req.body.metadata && !req.userIsAdmin) {
+    next(new ForbiddenError('Only admins are allowed to specify custom metadata for data changes'));
+  } else {
+    next();
+  }
+}

--- a/src/models/metadata.js
+++ b/src/models/metadata.js
@@ -32,6 +32,7 @@ module.exports = (sequelize, DataTypes) => {
     previous_value: DataTypes.TEXT,
     replacement_value: DataTypes.TEXT,
     updated_by: DataTypes.TEXT,
+    source: DataTypes.TEXT,
   }, {
     tableName: 'metadata',
     underscored: true,

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,7 @@ import taxonomy from './controllers/taxonomy';
 import languages from './controllers/languages';
 import comments from './controllers/comments';
 import getUser from './middleware/get-user';
+import dataEntryAuth from './middleware/data-entry-auth';
 import {
   NotFoundError,
   AuthError,
@@ -14,8 +15,8 @@ import {
 
 export default (app) => {
   app.get('/organizations', organizations.find);
-  app.post('/organizations', getUser, organizations.create);
-  app.patch('/organizations/:organizationId', getUser, organizations.update);
+  app.post('/organizations', getUser, dataEntryAuth, organizations.create);
+  app.patch('/organizations/:organizationId', getUser, dataEntryAuth, organizations.update);
   app.get('/organizations/:organizationId/locations', organizations.getLocations);
 
   app.get('/locations', locations.find);
@@ -23,15 +24,15 @@ export default (app) => {
   app.post('/locations/suggestions', locations.suggestNew);
 
   app.get('/locations/:locationId', locations.getInfo);
-  app.post('/locations', getUser, locations.create);
-  app.patch('/locations/:locationId', getUser, locations.update);
+  app.post('/locations', getUser, dataEntryAuth, locations.create);
+  app.patch('/locations/:locationId', getUser, dataEntryAuth, locations.update);
 
-  app.post('/locations/:locationId/phones', getUser, locations.addPhone);
-  app.patch('/phones/:phoneId', getUser, locations.updatePhone);
+  app.post('/locations/:locationId/phones', getUser, dataEntryAuth, locations.addPhone);
+  app.patch('/phones/:phoneId', getUser, dataEntryAuth, locations.updatePhone);
   app.delete('/phones/:phoneId', getUser, locations.deletePhone);
 
-  app.post('/services', getUser, services.create);
-  app.patch('/services/:serviceId', getUser, services.update);
+  app.post('/services', getUser, dataEntryAuth, services.create);
+  app.patch('/services/:serviceId', getUser, dataEntryAuth, services.update);
 
   app.get('/taxonomy', taxonomy.getAll);
   app.get('/languages', languages.getAll);

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -14,7 +14,7 @@ export const eligibilityParams = {
   gender: 'gender',
 };
 
-const updateHours = async (service, hours, t, user) => {
+const updateHours = async (service, hours, { t, user, metadata }) => {
   await models.RegularSchedule.destroy({ where: { service_id: service.id }, transaction: t });
 
   const modelCreateFunction = models.RegularSchedule.create.bind(models.RegularSchedule);
@@ -23,10 +23,10 @@ const updateHours = async (service, hours, t, user) => {
     weekday: getDayOfWeekInteger(hoursPart.weekday),
     opens_at: hoursPart.opensAt,
     closes_at: hoursPart.closesAt,
-  }, { transaction: t })));
+  }, { transaction: t, metadata })));
 };
 
-const updateIrregularHours = async (service, hours, t, user) => {
+const updateIrregularHours = async (service, hours, { t, user, metadata }) => {
   const relevantOccasions = [...new Set(hours.map(({ occasion }) => occasion))];
   await models.HolidaySchedule.destroy({
     where: {
@@ -46,22 +46,22 @@ const updateIrregularHours = async (service, hours, t, user) => {
     end_date: hoursPart.endDate,
     occasion: hoursPart.occasion,
     weekday: hoursPart.weekday != null ? getDayOfWeekInteger(hoursPart.weekday) : undefined,
-  }, { transaction: t })));
+  }, { transaction: t, metadata })));
 };
 
 // TODO: This is far less efficient than "service.setLanguages(languageIds, { transaction: t })".
 // Need to track metadata without having to explicitly insert (/delete) every instance.
-const updateLanguages = async (service, languageIds, t, user) => {
+const updateLanguages = async (service, languageIds, { t, user, metadata }) => {
   await models.ServiceLanguages.destroy({ where: { service_id: service.id }, transaction: t });
 
   const modelCreateFunction = models.ServiceLanguages.create.bind(models.ServiceLanguages);
   await Promise.all(languageIds.map(languageId => createInstance(user, modelCreateFunction, {
     service_id: service.id,
     language_id: languageId,
-  }, { transaction: t })));
+  }, { transaction: t, metadata })));
 };
 
-const updateDocuments = async (user, service, documents, t) => {
+const updateDocuments = async (service, documents, { t, user, metadata }) => {
   const {
     proofs,
     recertificationTime,
@@ -75,7 +75,7 @@ const updateDocuments = async (user, service, documents, t) => {
       createInstance(user, models.RequiredDocument.create.bind(models.RequiredDocument), {
         service_id: service.id,
         document: proof,
-      }, { transaction: t })));
+      }, { transaction: t, metadata })));
   }
 
   const documentsInfoUpdates = {};
@@ -85,10 +85,15 @@ const updateDocuments = async (user, service, documents, t) => {
   if (gracePeriod != null) { documentsInfoUpdates.grace_period = gracePeriod; }
   if (additionalInfo != null) { documentsInfoUpdates.additional_info = additionalInfo; }
 
-  await updateInstance(user, service.DocumentsInfo, documentsInfoUpdates, { transaction: t });
+  await updateInstance(
+    user,
+    service.DocumentsInfo,
+    documentsInfoUpdates,
+    { transaction: t, metadata },
+  );
 };
 
-const updateEventRelatedInfo = async (service, eventRelatedInfo, t, user) => {
+const updateEventRelatedInfo = async (service, eventRelatedInfo, { t, user, metadata }) => {
   await models.EventRelatedInfo.destroy({
     where: {
       service_id: service.id,
@@ -102,10 +107,15 @@ const updateEventRelatedInfo = async (service, eventRelatedInfo, t, user) => {
     service_id: service.id,
     event: eventRelatedInfo.event,
     information: eventRelatedInfo.information,
-  }, { transaction: t });
+  }, { transaction: t, metadata });
 };
 
-export const updateService = (service, update, user) => sequelize.transaction(async (t) => {
+export const updateService = (
+  service,
+  update,
+  user,
+  metadata,
+) => sequelize.transaction(async (t) => {
   const {
     taxonomy,
     hours,
@@ -125,23 +135,23 @@ export const updateService = (service, update, user) => sequelize.transaction(as
   }
 
   if (hours) {
-    updatePromises.push(updateHours(service, hours, t, user));
+    updatePromises.push(updateHours(service, hours, { t, user, metadata }));
   }
 
   if (irregularHours) {
-    updatePromises.push(updateIrregularHours(service, irregularHours, t, user));
+    updatePromises.push(updateIrregularHours(service, irregularHours, { t, user, metadata }));
   }
 
   if (eventRelatedInfo) {
-    updatePromises.push(updateEventRelatedInfo(service, eventRelatedInfo, t, user));
+    updatePromises.push(updateEventRelatedInfo(service, eventRelatedInfo, { t, user, metadata }));
   }
 
   if (languageIds) {
-    updatePromises.push(updateLanguages(service, languageIds, t, user));
+    updatePromises.push(updateLanguages(service, languageIds, { t, user, metadata }));
   }
 
   if (documents) {
-    updatePromises.push(updateDocuments(user, service, documents, t));
+    updatePromises.push(updateDocuments(service, documents, { t, user, metadata }));
   }
 
   const editableFields = [
@@ -161,7 +171,7 @@ export const updateService = (service, update, user) => sequelize.transaction(as
       ages_served: agesServed,
       who_does_it_serve: whoDoesItServe,
     },
-    { fields: editableFields, transaction: t },
+    { fields: editableFields, transaction: t, metadata },
   ));
 
   await Promise.all(updatePromises);
@@ -171,6 +181,7 @@ export const createService = async (
   location,
   serviceData,
   user,
+  metadata,
 ) => sequelize.transaction(async (t) => {
   const {
     name,
@@ -187,18 +198,18 @@ export const createService = async (
     url,
     additional_info: additionalInfo,
     organization_id: location.organization_id,
-  }, { transaction: t });
+  }, { transaction: t, metadata });
 
   await createInstance(user, models.ServiceTaxonomy.create.bind(models.ServiceTaxonomy), {
     service_id: createdService.id,
     taxonomy_id: taxonomy.id,
-  }, { transaction: t });
+  }, { transaction: t, metadata });
 
   await createInstance(
     user,
     models.DocumentsInfo.create.bind(models.DocumentsInfo),
     { service_id: createdService.id },
-    { transaction: t },
+    { transaction: t, metadata },
   );
 
   return createdService;

--- a/test/integration/create-organization.test.js
+++ b/test/integration/create-organization.test.js
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import app from '../../src/app';
+import models from '../../src/models';
+
+describe('create organization', () => {
+  const orgParams = {
+    name: 'New Org',
+    description: 'An organization created through an API request.',
+    url: 'www.streetlives.com',
+  };
+
+  afterEach(() => Promise.all([
+    models.Organization.destroy({ where: {} }),
+    models.Metadata.destroy({ where: {} }),
+  ]));
+
+  it('should create an organization in the DB', async () => {
+    await request(app)
+      .post('/organizations')
+      .send(orgParams)
+      .expect(201);
+
+    const dbOrg = await models.Organization.findOne({ name: orgParams.name });
+    expect(dbOrg).toHaveProperty('description', orgParams.description);
+    expect(dbOrg).toHaveProperty('url', orgParams.url);
+  });
+
+  describe('when no custom metadata is specified', () => {
+    it('should create metadata with current time as the last action date', async () => {
+      const startTime = Date.now();
+      await request(app)
+        .post('/organizations')
+        .send(orgParams)
+        .expect(201);
+      const endTime = Date.now();
+
+      const dbOrg = await models.Organization.findOne({ name: orgParams.name });
+      const latestUpdate = await models.Metadata.getLatestUpdateDateForResource(dbOrg.id);
+
+      const latestUpdateTime = latestUpdate.getTime();
+      expect(latestUpdateTime).toBeGreaterThanOrEqual(startTime);
+      expect(latestUpdateTime).toBeLessThanOrEqual(endTime);
+    });
+  });
+
+  describe('when custom metadata is specified', () => {
+    it('should create metadata based on the parameters specified', async () => {
+      const customLastUpdated = new Date('2020-01-01T20:10:00');
+      await request(app)
+        .post('/organizations')
+        .send({ ...orgParams, metadata: { lastUpdated: customLastUpdated } })
+        .expect(201);
+
+      const dbOrg = await models.Organization.findOne({ name: orgParams.name });
+      const latestUpdate = await models.Metadata.getLatestUpdateDateForResource(dbOrg.id);
+      expect(latestUpdate).toEqual(customLastUpdated);
+    });
+  });
+});


### PR DESCRIPTION
Store in metadata the source from which data came

- Add "source" column to metadata table, for storing where (imported)
  data came from, and a migration for it.
- Allow admin users to specify the source and time of last update of
  data when creating/updating it (for imports using the API, e.g. FPC).