### PR TITLE
feature: support deleting services (from SSTT)

### DIFF
--- a/src/controllers/services.js
+++ b/src/controllers/services.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 import serviceSchemas from './validation/services';
 import models from '../models';
-import { createService, updateService } from '../services/services';
+import { createService, updateService, deleteService } from '../services/services';
 import { NotFoundError } from '../utils/errors';
 
 export default {
@@ -64,6 +64,19 @@ export default {
       }
 
       await updateService(service, { ...otherProps, taxonomy }, req.user, metadata);
+      res.sendStatus(204);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  delete: async (req, res, next) => {
+    try {
+      await Joi.validate(req, serviceSchemas.delete, { allowUnknown: true });
+      const { serviceId } = req.params;
+
+      await deleteService(serviceId, req.user);
+
       res.sendStatus(204);
     } catch (err) {
       next(err);

--- a/src/controllers/validation/locations.js
+++ b/src/controllers/validation/locations.js
@@ -66,7 +66,7 @@ export default {
       locationId: Joi.string().guid().required(),
     }).required(),
     body: Joi.object().keys({
-      name: Joi.string(),
+      name: Joi.string().allow(null),
       description: Joi.string(),
       latitude: Joi.number(),
       longitude: Joi.number(),

--- a/src/controllers/validation/services.js
+++ b/src/controllers/validation/services.js
@@ -77,4 +77,10 @@ export default {
       metadata: updateMetadataSchema,
     }).required(),
   },
+
+  delete: {
+    params: Joi.object().keys({
+      serviceId: Joi.string().guid().required(),
+    }).required(),
+  },
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -34,6 +34,7 @@ export default (app) => {
 
   app.post('/services', getUser, dataEntryAuth, services.create);
   app.patch('/services/:serviceId', getUser, dataEntryAuth, services.update);
+  app.delete('/services/:serviceId', getUser, services.delete);
 
   app.get('/taxonomy', taxonomy.getAll);
   app.get('/languages', languages.getAll);

--- a/src/services/data-changes.js
+++ b/src/services/data-changes.js
@@ -88,13 +88,14 @@ export const updateInstance = async (user, instance, values, options = {}) =>
     return newInstance;
   }, options);
 
-export const destroyInstance = (user, instance) => startTransactionOrUseExisting(async (t) => {
-  await instance.destroy({ transaction: t });
+export const destroyInstance = (user, instance, options = {}) =>
+  startTransactionOrUseExisting(async (t) => {
+    await instance.destroy({ transaction: t });
 
-  await instance.createMetadatum({
-    resource_id: instance.id,
-    last_action_date: new Date(),
-    last_action_type: actionTypes.delete,
-    updated_by: user,
-  }, { transaction: t });
-});
+    await instance.createMetadatum({
+      resource_id: instance.id,
+      last_action_date: new Date(),
+      last_action_type: actionTypes.delete,
+      updated_by: user,
+    }, { transaction: t });
+  }, options);


### PR DESCRIPTION
- Allow specifying transaction when destroying an instance.
- Add route for deleting services.
- When deleting, destroy service and all associations in a transaction,
  and record in metadata the service and the location it belonged to.

(Unrelatedly: Allow clearing location name when updating a location.)