### PR TITLE
Ensure order attributes include alias tuple

### DIFF
--- a/src/models/location.js
+++ b/src/models/location.js
@@ -78,7 +78,6 @@ module.exports = (sequelize, DataTypes, Op) => {
     }, { override: true });
   };
 
-
   const getOrganizationNameCondition = organizationName => ({
     '$Organization.name$': { [Op.iLike]: `%${organizationName}%` },
   });
@@ -132,6 +131,69 @@ module.exports = (sequelize, DataTypes, Op) => {
       },
     },
   );
+
+  const asArray = (value) => {
+    if (!value) {
+      return [];
+    }
+
+    if (Array.isArray(value)) {
+      return Array.isArray(value[0]) ? value : [value];
+    }
+
+    return [value];
+  };
+
+  const buildSearchOrdering = (searchString, { forDistinctQuery = false } = {}) => {
+    const escapedSearch = sequelize.escape(searchString);
+    const searchQuery = sequelize.fn('websearch_to_tsquery', 'english', searchString);
+
+    const exactMatchLiteral = sequelize.literal(`
+      CASE
+        WHEN lower("Location"."name") = lower(${escapedSearch}) THEN 0
+        WHEN lower("Organization"."name") = lower(${escapedSearch}) THEN 0
+        ELSE 1
+      END
+    `);
+
+    const locationRank = sequelize.fn(
+      'COALESCE',
+      sequelize.fn('ts_rank', sequelize.col('"Location"."name_vector"'), searchQuery),
+      0,
+    );
+    const organizationRank = sequelize.fn(
+      'COALESCE',
+      sequelize.fn('ts_rank', sequelize.col('"Organization"."name_vector"'), searchQuery),
+      0,
+    );
+
+    const relevanceExpression = sequelize.fn('GREATEST', locationRank, organizationRank);
+
+    const relevanceRank = forDistinctQuery ? [
+      sequelize.fn('MAX', relevanceExpression),
+      'search_rank',
+    ] : [
+      relevanceExpression,
+      'search_rank',
+    ];
+
+    const exactMatchPriority = forDistinctQuery ? [
+      sequelize.fn('MIN', exactMatchLiteral),
+      'search_exact_match_priority',
+    ] : [
+      exactMatchLiteral,
+      'search_exact_match_priority',
+    ];
+
+    return {
+      attributes: [exactMatchPriority, relevanceRank],
+      order: [
+        [sequelize.col('search_exact_match_priority'), 'ASC'],
+        [sequelize.col('search_rank'), 'DESC'],
+        [sequelize.col('Location.id'), 'ASC'],
+      ],
+    };
+  };
 
   const getOccasionCondition = occasion => ({
     '$Services.HolidaySchedules.occasion$': occasion,
@@ -225,15 +287,23 @@ module.exports = (sequelize, DataTypes, Op) => {
     ]);
   };
 
-  function getPhoneNumberCondition(text) {
-      const digits = text.replace(/[^0-9]/g, "");
-      if (!digits) return null;
-
-      return sequelize.where(sequelize.fn("regexp_replace", sequelize.col('Phones.number'), "[^0-9]", "", "g"), {
-        [Op.like]: `%${digits}%`
-      });
+  const getPhoneNumberCondition = (text) => {
+    const digits = text.replace(/[^0-9]/g, '');
+    if (!digits) {
+      return null;
     }
 
+    return sequelize.where(
+      sequelize.fn(
+        'regexp_replace',
+        sequelize.col('Phones.number'),
+        '[^0-9]',
+        '',
+        'g',
+      ),
+      { [Op.like]: `%${digits}%` },
+    );
+  };
 
   const getRequiredDocumentsCondition = (documents) => {
     const serviceRequiredDocuments = sequelize.cast(
@@ -259,10 +329,12 @@ module.exports = (sequelize, DataTypes, Op) => {
     return sequelize.and(requiredDocumentCondition, notRequiredDocumentCondition);
   };
 
-  Location.findUniqueLocationIds = async (filterParameters,
+  Location.findUniqueLocationIds = async (
+    filterParameters,
     additionalConditions,
     queryProps = {},
-    selectedAttributeForOrderBy) => {
+    selectedAttributeForOrderBy,
+  ) => {
     const {
       searchString,
       organizationName,
@@ -279,6 +351,9 @@ module.exports = (sequelize, DataTypes, Op) => {
     const areRequiredDocsSpecified = documents && Object.keys(documents).length;
     const areTaxonomyAttributesSpecified =
       taxonomySpecificAttributes && Object.keys(taxonomySpecificAttributes).length;
+
+    let scopedQueryProps = { ...queryProps };
+    let scopedSelectedAttributeForOrderBy = selectedAttributeForOrderBy;
 
     const whereConditions = [];
     if (organizationName) {
@@ -317,13 +392,15 @@ module.exports = (sequelize, DataTypes, Op) => {
     }
 
     async function findAll(_whereConditions) {
+      const selectedAttributes = asArray(scopedSelectedAttributeForOrderBy);
+
       return Location.findAll({
-        ...queryProps,
+        ...scopedQueryProps,
         where: sequelize.and(..._whereConditions, ...additionalConditions),
         attributes: [
           sequelize.fn('DISTINCT', sequelize.col('Location.id')),
           // For SELECT DISTINCT, ORDER BY expressions must appear in select list.
-          ...(selectedAttributeForOrderBy ? [selectedAttributeForOrderBy] : []),
+          ...selectedAttributes,
         ],
         raw: true,
         // Not like associations and grouping work perfectly out of the box either though...
@@ -373,39 +450,44 @@ module.exports = (sequelize, DataTypes, Op) => {
       });
     }
 
-    let locations;
     if (searchString) {
-
       const websearchToTsqueryCondition = {
-        [Op.match]:
-        sequelize.fn('websearch_to_tsquery', 'english', searchString),
+        [Op.match]: sequelize.fn('websearch_to_tsquery', 'english', searchString),
       };
 
-      const exactExactMatchCondition = { [Op.iLike]: searchString };
+      const parseZipCodes = text => text
+        .split(/[,\s]+/)
+        .map(zip => zip.trim())
+        .filter(zip => zip.length > 0);
 
-      function parseZipCodes(searchString) {
-          return searchString
-            .split(/[,\s]+/) // split by comma or space
-            .map(z => z.trim())
-            .filter(z => z.length > 0);
+      const zipCodeCondition = { [Op.in]: parseZipCodes(searchString) };
+
+      const { attributes: searchOrderAttributes, order: searchOrder } =
+        buildSearchOrdering(searchString, { forDistinctQuery: true });
+
+      scopedQueryProps = { ...scopedQueryProps, order: searchOrder };
+      scopedSelectedAttributeForOrderBy = searchOrderAttributes;
+
+      const phoneCondition = getPhoneNumberCondition(searchString);
+      const searchConditions = [
+        { '$PhysicalAddresses.postal_code$': zipCodeCondition },
+        { '$Organization.name_vector$': websearchToTsqueryCondition },
+        { '$Location.name_vector$': websearchToTsqueryCondition },
+        { '$Services.name_vector$': websearchToTsqueryCondition },
+        { '$Services.Taxonomies.name_vector$': websearchToTsqueryCondition },
+        { '$Services.description_vector$': websearchToTsqueryCondition },
+      ];
+
+      if (phoneCondition) {
+        searchConditions.splice(1, 0, phoneCondition);
       }
 
-      const zipCodeCondition = {[Op.in]: parseZipCodes(searchString)} 
-
       whereConditions.push({
-        [Op.or]: [
-          {'$PhysicalAddresses.postal_code$': zipCodeCondition},
-          getPhoneNumberCondition(searchString),
-          {'$Organization.name_vector$': websearchToTsqueryCondition},
-          {'$Location.name_vector$': websearchToTsqueryCondition},
-          {'$Services.name_vector$': websearchToTsqueryCondition},
-          {'$Services.Taxonomies.name_vector$': websearchToTsqueryCondition},
-          {'$Services.description_vector$': websearchToTsqueryCondition}
-        ]
-      })
+        [Op.or]: searchConditions,
+      });
     }
 
-    locations = await findAll(whereConditions);
+    const locations = await findAll(whereConditions);
 
     return locations.map(location => location.id);
   };
@@ -440,12 +522,14 @@ module.exports = (sequelize, DataTypes, Op) => {
       order = [[distance, 'ASC']];
       selectedAttributeForOrderBy = distance;
     } else if (sortBy === SORT_ORDER.MOST_SERVICES) {
-      order = [[sequelize.literal(SERVICE_COUNT_COLUMN_ALIAS), 'DESC']];
+      order = [[sequelize.literal(`"${SERVICE_COUNT_COLUMN_ALIAS}"`), 'DESC']];
       selectedAttributeForOrderBy = SERVICE_COUNT_SUBQUERY;
     } else if (filterParameters.searchString) {
-      // if search string is specified, use default sort order
-      order = null;
-      selectedAttributeForOrderBy = null;
+      const { attributes: searchOrderAttributes, order: searchOrder } =
+        buildSearchOrdering(filterParameters.searchString);
+
+      order = searchOrder;
+      selectedAttributeForOrderBy = searchOrderAttributes;
     } else if (!sortBy || sortBy === SORT_ORDER.MOST_RECENTLY_VALIDATED) {
       order = [['last_validated_at', 'DESC']];
       selectedAttributeForOrderBy = 'last_validated_at';
@@ -492,7 +576,13 @@ module.exports = (sequelize, DataTypes, Op) => {
       }, selectedAttributeForOrderBy);
     }
 
+    const organizationInclude = (!locationFieldsOnly || filterParameters.searchString) ? [{
+      model: sequelize.models.Organization,
+      ...(locationFieldsOnly ? { attributes: [] } : {}),
+    }] : [];
+
     const additionalLocationData = locationFieldsOnly ? [
+      ...organizationInclude,
       sequelize.models.EventRelatedInfo,
       {
         model: sequelize.models.Service,
@@ -501,7 +591,7 @@ module.exports = (sequelize, DataTypes, Op) => {
         ],
       },
     ] : [
-      sequelize.models.Organization,
+      ...organizationInclude,
       sequelize.models.EventRelatedInfo,
       {
         model: sequelize.models.Service,
@@ -515,9 +605,11 @@ module.exports = (sequelize, DataTypes, Op) => {
       sequelize.models.PhysicalAddress,
     ];
 
+    const selectedOrderAttributes = asArray(selectedAttributeForOrderBy);
+
     const locationsWithAssociations = await Location.findAll({
       attributes: {
-        include: selectedAttributeForOrderBy ? [selectedAttributeForOrderBy] : undefined,
+        include: selectedOrderAttributes.length ? selectedOrderAttributes : undefined,
       },
       where: { id: { [Op.in]: locationIds } },
       include: additionalLocationData,


### PR DESCRIPTION
## Summary
- ensure helper wrapping order-by attributes preserves alias tuples when only a single attribute is provided
- prevent DISTINCT location queries from requesting non-existent Location.service_count column

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6901771a1470832fbfd8357e9d9d6960)