### PR TITLE
Avoid RDS proxy session pinning

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -21,7 +21,7 @@ export default {
         // idle: parseNumber(process.env.DATABASE_POOL_IDLE_TIME, 10000), // let the RDS proxy handle timeout
       },
       dialectOptions: {
-        clientMinMessages: false, // avoid issuing SET client_min_messages
+        clientMinMessages: 'ignore', // avoid issuing SET client_min_messages
         ssl: {
           require: true,
           rejectUnauthorized: false, // For RDS, set to false to accept AWS certificates

--- a/src/config.js
+++ b/src/config.js
@@ -14,12 +14,14 @@ export default {
       logging: parseBoolean(process.env.DATABASE_LOGGING, true),
       dialect: 'postgres',
       operatorsAliases: false,
+      keepDefaultTimezone: true, // avoid issuing SET TIME ZONE
       pool: {
         max: parseNumber(process.env.DATABASE_POOL_MAX, 1),
         min: parseNumber(process.env.DATABASE_POOL_MIN, 0),
         // idle: parseNumber(process.env.DATABASE_POOL_IDLE_TIME, 10000), // let the RDS proxy handle timeout
       },
       dialectOptions: {
+        clientMinMessages: false, // avoid issuing SET client_min_messages
         ssl: {
           require: true,
           rejectUnauthorized: false, // For RDS, set to false to accept AWS certificates


### PR DESCRIPTION
## Summary
- configure Sequelize to keep the default timezone so initialization avoids SET TIME ZONE
- disable client_min_messages initialization to reduce session pinning in RDS Proxy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69528fb290fc8327900fb18fca196b1e)