### PR TITLE
Post Codex blocking feedback as a REQUEST_CHANGES review

### DIFF
--- a/.github/workflows/codex-auto-approve.yml
+++ b/.github/workflows/codex-auto-approve.yml
@@ -104,6 +104,7 @@ jobs:
           echo "summary<<EOF" >> "$GITHUB_OUTPUT"
           jq -r .summary codex-review.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "blocking_issues_json=$(jq -c '.blocking_issues' codex-review.json)" >> "$GITHUB_OUTPUT"
 
       - name: Approve PR if Codex says APPROVE and author is trusted
         if: steps.parse.outputs.decision == 'APPROVE' && steps.allow.outputs.trusted == 'true'
@@ -119,5 +120,35 @@ jobs:
               pull_number: context.payload.pull_request.number,
               event: "APPROVE",
               body: process.env.SUMMARY || "Codex: approved.",
+              commit_id: context.payload.pull_request.head.sha,
+            });
+
+      - name: Request changes if Codex says REQUEST_CHANGES
+        if: steps.parse.outputs.decision == 'REQUEST_CHANGES'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0 (tag v7)
+        env:
+          SUMMARY: ${{ steps.parse.outputs.summary }}
+          BLOCKING_ISSUES_JSON: ${{ steps.parse.outputs.blocking_issues_json }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const blockingIssues = JSON.parse(process.env.BLOCKING_ISSUES_JSON || "[]");
+            const issueList = blockingIssues.length
+              ? blockingIssues.map((issue) => `- ${issue}`).join("\n")
+              : "- No blocking issues were returned.";
+
+            const body = [
+              process.env.SUMMARY || "Codex: changes requested.",
+              "",
+              "### Blocking issues",
+              issueList,
+            ].join("\n");
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: "REQUEST_CHANGES",
+              body,
               commit_id: context.payload.pull_request.head.sha,
             });


### PR DESCRIPTION
### Motivation
- Make LLM feedback from the Codex auto-approve workflow more discoverable by posting `blocking_issues` and the summary as an actual PR review when the model returns `REQUEST_CHANGES`.

### Description
- Parse and expose `blocking_issues` from `codex-review.json` as `blocking_issues_json` in the `Parse decision` step using `jq -c`.
- Add a conditional `Request changes if Codex says REQUEST_CHANGES` step that uses `actions/github-script` to create a PR review with `event: "REQUEST_CHANGES"`.
- The new review body includes the `summary` plus a markdown bullet list of `blocking_issues` (or a fallback line when none are returned), and the existing `APPROVE` flow is unchanged.

### Testing
- Validated the modified workflow is syntactically loadable with Ruby YAML parsing via `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codex-auto-approve.yml"); puts "ok"'`, which succeeded.
- Inspected the workflow diff and line output to confirm the new `blocking_issues_json` output and the `REQUEST_CHANGES` review step are present.
- Running the repository pre-commit lint hook surfaced many unrelated lint errors in other files (pre-existing automated failures), which prevented a clean pre-commit pass for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991ad9c2c48327a663c6099e337544)