### PR TITLE
Add internal paginated location catalog for Sheets and extension

### DIFF
--- a/simple-proxy-api.yaml
+++ b/simple-proxy-api.yaml
@@ -47,7 +47,7 @@ paths:
             responseParameters:
               method.response.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Origin: "'https://example.com'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
         passthroughBehavior: when_no_match
         requestTemplates:
           application/json: "{\"statusCode\": 200}"
@@ -90,7 +90,7 @@ paths:
             responseParameters:
               method.response.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Origin: "'https://example.com'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
         passthroughBehavior: when_no_match
         requestTemplates:
           application/json: "{\"statusCode\": 200}"

--- a/simple-proxy-api.yaml
+++ b/simple-proxy-api.yaml
@@ -47,7 +47,7 @@ paths:
             responseParameters:
               method.response.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Origin: "'*'"
+              method.response.header.Access-Control-Allow-Origin: "'https://sheets.doobneek.org'"
         passthroughBehavior: when_no_match
         requestTemplates:
           application/json: "{\"statusCode\": 200}"
@@ -90,7 +90,7 @@ paths:
             responseParameters:
               method.response.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Origin: "'*'"
+              method.response.header.Access-Control-Allow-Origin: "'https://sheets.doobneek.org'"
         passthroughBehavior: when_no_match
         requestTemplates:
           application/json: "{\"statusCode\": 200}"

--- a/simple-proxy-api.yaml
+++ b/simple-proxy-api.yaml
@@ -47,11 +47,28 @@ paths:
             responseParameters:
               method.response.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Origin: "'https://sheets.doobneek.org'"
+              method.response.header.Access-Control-Allow-Origin: "'https://example.com'"
         passthroughBehavior: when_no_match
         requestTemplates:
           application/json: "{\"statusCode\": 200}"
         type: mock
+  /locations/catalog:
+    x-amazon-apigateway-any-method:
+      produces:
+      - application/json
+      responses: {}
+      x-amazon-apigateway-integration:
+        uri: arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:710263499164:function:${stageVariables.ServerlessExpressLambdaFunctionName}/invocations
+        httpMethod: POST
+        type: aws_proxy
+    options:
+      produces:
+      - application/json
+      responses: {}
+      x-amazon-apigateway-integration:
+        uri: arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:710263499164:function:${stageVariables.ServerlessExpressLambdaFunctionName}/invocations
+        httpMethod: POST
+        type: aws_proxy
   /{proxy+}:
     x-amazon-apigateway-any-method:
       produces:
@@ -90,7 +107,7 @@ paths:
             responseParameters:
               method.response.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Origin: "'https://sheets.doobneek.org'"
+              method.response.header.Access-Control-Allow-Origin: "'https://example.com'"
         passthroughBehavior: when_no_match
         requestTemplates:
           application/json: "{\"statusCode\": 200}"

--- a/src/app.js
+++ b/src/app.js
@@ -1,23 +1,20 @@
 import express from 'express';
 import bodyParser from 'body-parser';
-import cors from 'cors';
 import morgan from 'morgan';
 import awsServerlessExpressMiddleware from 'aws-serverless-express/middleware';
 import setupRoutes from './routes';
+import { publicApiCors, internalLocationCatalogCors } from './services/internal-location-catalog-cors';
 
 const app = express();
-const exposedHeaders = [
-  'Pagination-Count',
-  'Total-Count',
-  'Page-Number',
-  'Page-Size',
-  'Has-More',
-  'Next-Page',
-];
 
 app.use(morgan('dev'));
 
-app.use(cors({ exposedHeaders }));
+app.use((req, res, next) => {
+  if (req.path === '/locations/catalog') {
+    return internalLocationCatalogCors(req, res, next);
+  }
+  return publicApiCors(req, res, next);
+});
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 

--- a/src/app.js
+++ b/src/app.js
@@ -6,10 +6,18 @@ import awsServerlessExpressMiddleware from 'aws-serverless-express/middleware';
 import setupRoutes from './routes';
 
 const app = express();
+const exposedHeaders = [
+  'Pagination-Count',
+  'Total-Count',
+  'Page-Number',
+  'Page-Size',
+  'Has-More',
+  'Next-Page',
+];
 
 app.use(morgan('dev'));
 
-app.use(cors());
+app.use(cors({ exposedHeaders }));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 

--- a/src/app.js
+++ b/src/app.js
@@ -9,8 +9,12 @@ const app = express();
 
 app.use(morgan('dev'));
 
+function isInternalLocationCatalogPath(path) {
+  return path === '/locations/catalog' || path.startsWith('/locations/catalog/');
+}
+
 app.use((req, res, next) => {
-  if (req.path === '/locations/catalog') {
+  if (isInternalLocationCatalogPath(req.path)) {
     return internalLocationCatalogCors(req, res, next);
   }
   return publicApiCors(req, res, next);

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,58 @@
 import { parseBoolean, parseNumber } from './utils/strings';
 
+const DEFAULT_COGNITO_USER_POOL_ID = 'us-east-1_EvBbozIjd';
+const DEFAULT_INTERNAL_CATALOG_ALLOWED_HOSTS = ['sheets.doobneek.org'];
+const DEFAULT_INTERNAL_CATALOG_MAX_RADIUS_METERS = Math.round(20 * 1609.344);
+const DEFAULT_INTERNAL_CATALOG_DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_INTERNAL_CATALOG_MAX_PAGE_SIZE = 1000;
+
+const parseCsv = (value, fallback = []) => {
+  if (typeof value !== 'string') return fallback;
+  const parsed = value
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean);
+  return parsed.length ? parsed : fallback;
+};
+
+const cognitoUserPoolId = process.env.COGNITO_USER_POOL_ID || DEFAULT_COGNITO_USER_POOL_ID;
+const cognitoUserPoolRegion = process.env.COGNITO_USER_POOL_REGION
+  || (cognitoUserPoolId.includes('_') ? cognitoUserPoolId.split('_')[0] : 'us-east-1');
+const cognitoUserPoolIssuer = cognitoUserPoolId
+  ? `https://cognito-idp.${cognitoUserPoolRegion}.amazonaws.com/${cognitoUserPoolId}`
+  : null;
+const internalCatalogMaxPageSize = parseNumber(
+  process.env.INTERNAL_LOCATION_CATALOG_MAX_PAGE_SIZE,
+  DEFAULT_INTERNAL_CATALOG_MAX_PAGE_SIZE,
+);
+
 export default {
   port: process.env.PORT || 3000,
   slackWebhookUrl: process.env.SLACK_WEBHOOK_URL,
   adminGroupName: process.env.ADMIN_GROUP_NAME || 'StreetlivesAdmins',
+  cognito: {
+    userPoolId: cognitoUserPoolId,
+    userPoolRegion: cognitoUserPoolRegion,
+    userPoolIssuer: cognitoUserPoolIssuer,
+  },
+  internalLocationCatalog: {
+    allowedOriginHosts: parseCsv(
+      process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_HOSTS,
+      DEFAULT_INTERNAL_CATALOG_ALLOWED_HOSTS,
+    ),
+    maxRadiusMeters: parseNumber(
+      process.env.INTERNAL_LOCATION_CATALOG_MAX_RADIUS_METERS,
+      DEFAULT_INTERNAL_CATALOG_MAX_RADIUS_METERS,
+    ),
+    defaultPageSize: Math.min(
+      parseNumber(
+        process.env.INTERNAL_LOCATION_CATALOG_DEFAULT_PAGE_SIZE,
+        DEFAULT_INTERNAL_CATALOG_DEFAULT_PAGE_SIZE,
+      ),
+      internalCatalogMaxPageSize,
+    ),
+    maxPageSize: internalCatalogMaxPageSize,
+  },
   db: {
     database: process.env.DATABASE_NAME || 'streetlives',
     username: process.env.DATABASE_USER,

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,7 @@
 import { parseBoolean, parseNumber } from './utils/strings';
 
-const DEFAULT_COGNITO_USER_POOL_ID = 'us-east-1_EvBbozIjd';
 const DEFAULT_INTERNAL_CATALOG_ALLOWED_HOSTS = ['sheets.doobneek.org'];
-const DEFAULT_INTERNAL_CATALOG_ALLOWED_CLIENT_IDS = ['kpd58387a2f9e4fe1d42sfd1q'];
+const DEFAULT_INTERNAL_CATALOG_ALLOWED_ORIGIN_PATTERNS = ['chrome-extension://*'];
 const DEFAULT_INTERNAL_CATALOG_ALLOWED_GROUPS = [];
 const DEFAULT_INTERNAL_CATALOG_MAX_RADIUS_METERS = Math.round(20 * 1609.344);
 const DEFAULT_INTERNAL_CATALOG_DEFAULT_PAGE_SIZE = 500;
@@ -17,12 +16,12 @@ const parseCsv = (value, fallback = []) => {
   return parsed.length ? parsed : fallback;
 };
 
-const cognitoUserPoolId = process.env.COGNITO_USER_POOL_ID || DEFAULT_COGNITO_USER_POOL_ID;
+const cognitoUserPoolId = process.env.COGNITO_USER_POOL_ID || null;
 const cognitoUserPoolRegion = process.env.COGNITO_USER_POOL_REGION
-  || (cognitoUserPoolId.includes('_') ? cognitoUserPoolId.split('_')[0] : 'us-east-1');
-const cognitoUserPoolIssuer = cognitoUserPoolId
+  || (cognitoUserPoolId && cognitoUserPoolId.includes('_') ? cognitoUserPoolId.split('_')[0] : null);
+const cognitoUserPoolIssuer = process.env.COGNITO_USER_POOL_ISSUER || (cognitoUserPoolId
   ? `https://cognito-idp.${cognitoUserPoolRegion}.amazonaws.com/${cognitoUserPoolId}`
-  : null;
+  : null);
 const internalCatalogMaxPageSize = parseNumber(
   process.env.INTERNAL_LOCATION_CATALOG_MAX_PAGE_SIZE,
   DEFAULT_INTERNAL_CATALOG_MAX_PAGE_SIZE,
@@ -42,9 +41,13 @@ export default {
       process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_HOSTS,
       DEFAULT_INTERNAL_CATALOG_ALLOWED_HOSTS,
     ),
+    allowedOriginPatterns: parseCsv(
+      process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_ORIGIN_PATTERNS,
+      DEFAULT_INTERNAL_CATALOG_ALLOWED_ORIGIN_PATTERNS,
+    ),
     allowedClientIds: parseCsv(
       process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_CLIENT_IDS,
-      DEFAULT_INTERNAL_CATALOG_ALLOWED_CLIENT_IDS,
+      [],
     ),
     allowedGroupNames: parseCsv(
       process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_GROUP_NAMES,

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,8 @@ import { parseBoolean, parseNumber } from './utils/strings';
 
 const DEFAULT_COGNITO_USER_POOL_ID = 'us-east-1_EvBbozIjd';
 const DEFAULT_INTERNAL_CATALOG_ALLOWED_HOSTS = ['sheets.doobneek.org'];
+const DEFAULT_INTERNAL_CATALOG_ALLOWED_CLIENT_IDS = ['kpd58387a2f9e4fe1d42sfd1q'];
+const DEFAULT_INTERNAL_CATALOG_ALLOWED_GROUPS = [];
 const DEFAULT_INTERNAL_CATALOG_MAX_RADIUS_METERS = Math.round(20 * 1609.344);
 const DEFAULT_INTERNAL_CATALOG_DEFAULT_PAGE_SIZE = 500;
 const DEFAULT_INTERNAL_CATALOG_MAX_PAGE_SIZE = 1000;
@@ -39,6 +41,14 @@ export default {
     allowedOriginHosts: parseCsv(
       process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_HOSTS,
       DEFAULT_INTERNAL_CATALOG_ALLOWED_HOSTS,
+    ),
+    allowedClientIds: parseCsv(
+      process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_CLIENT_IDS,
+      DEFAULT_INTERNAL_CATALOG_ALLOWED_CLIENT_IDS,
+    ),
+    allowedGroupNames: parseCsv(
+      process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_GROUP_NAMES,
+      DEFAULT_INTERNAL_CATALOG_ALLOWED_GROUPS,
     ),
     maxRadiusMeters: parseNumber(
       process.env.INTERNAL_LOCATION_CATALOG_MAX_RADIUS_METERS,

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 import locationSchemas from './validation/locations';
 import models from '../models';
+import config from '../config';
 import { updateInstance, createInstance, destroyInstance } from '../services/data-changes';
 import {
   getMetadataForLocation,
@@ -12,9 +13,67 @@ import geometry from '../utils/geometry';
 import { parseBoolean } from '../utils/strings';
 import { convertKeyValueArrayToObject } from '../utils/api-params';
 import { NotFoundError, ValidationError } from '../utils/errors';
+import authorizeInternalLocationCatalogRequest from '../services/internal-location-catalog-auth';
 
 const DEFAULT_MAX_LOCATIONS_RETURNED = 1000;
 const MAX_TAXONOMY_IDS = 200;
+
+const setPaginationHeaders = (res, {
+  totalNumLocations,
+  pageNumber,
+  pageSize,
+}) => {
+  const paginationCount = pageSize > 0
+    ? Math.ceil(totalNumLocations / pageSize)
+    : 1;
+  const hasMore = pageNumber + 1 < paginationCount;
+  res.setHeader('Pagination-Count', paginationCount);
+  res.setHeader('Total-Count', totalNumLocations);
+  res.setHeader('Page-Number', pageNumber);
+  res.setHeader('Page-Size', pageSize);
+  res.setHeader('Has-More', hasMore ? 'true' : 'false');
+  if (hasMore) {
+    res.setHeader('Next-Page', pageNumber + 1);
+  } else {
+    res.removeHeader('Next-Page');
+  }
+};
+
+const getCoordinatesFromPosition = (position) => {
+  const coordinates = position && position.coordinates;
+  if (!Array.isArray(coordinates) || coordinates.length < 2) {
+    return {
+      latitude: null,
+      longitude: null,
+    };
+  }
+  return {
+    latitude: Number(coordinates[1]),
+    longitude: Number(coordinates[0]),
+  };
+};
+
+const formatCatalogLocation = (location) => {
+  const plainLocation = location.get({ plain: true });
+  const {
+    latitude,
+    longitude,
+  } = getCoordinatesFromPosition(plainLocation.position);
+  return {
+    id: plainLocation.id,
+    name: plainLocation.name,
+    slug: plainLocation.slug,
+    description: plainLocation.description,
+    additional_info: plainLocation.additional_info,
+    last_validated_at: plainLocation.last_validated_at,
+    position: plainLocation.position,
+    latitude,
+    longitude,
+    org: plainLocation.Organization ? plainLocation.Organization.name : null,
+    Organization: plainLocation.Organization || null,
+    PhysicalAddresses: plainLocation.PhysicalAddresses || [],
+  };
+};
 
 const isLocationClosed = (occasion, eventRelatedInfos, services) => {
   if (!occasion) {
@@ -292,6 +351,45 @@ export default {
     }
   },
 
+  findCatalog: async (req, res, next) => {
+    try {
+      await Joi.validate(req, locationSchemas.findCatalog, { allowUnknown: true });
+      await authorizeInternalLocationCatalogRequest(req);
+
+      const {
+        latitude,
+        longitude,
+        radius,
+        pageNumber: rawPageNumber,
+        pageSize: rawPageSize,
+        sortBy,
+      } = req.query;
+
+      const pageSize = rawPageSize != null
+        ? parseInt(rawPageSize, 10)
+        : config.internalLocationCatalog.defaultPageSize;
+      const pageNumber = rawPageNumber != null ? parseInt(rawPageNumber, 10) : 0;
+      const {
+        locations,
+        totalNumLocations,
+      } = await models.Location.findCatalog({
+        position: geometry.createPoint(Number(longitude), Number(latitude)),
+        radius: Number(radius),
+        limit: pageSize,
+        offset: pageNumber * pageSize,
+        sortBy,
+      });
+
+      setPaginationHeaders(res, {
+        totalNumLocations,
+        pageNumber,
+        pageSize,
+      });
+      res.send(locations.map(formatCatalogLocation));
+    } catch (err) {
+      next(err);
+    }
+  },
   getInfo: async (req, res, next) => {
     try {
       await Joi.validate(req, locationSchemas.getInfo, { allowUnknown: true });

--- a/src/controllers/validation/locations.js
+++ b/src/controllers/validation/locations.js
@@ -77,10 +77,10 @@ export default {
         .integer()
         .positive()
         .max(config.internalLocationCatalog.maxPageSize),
-      sortBy: Joi.string().valid([
+      sortBy: Joi.string().valid(
         SORT_ORDER.NEARBY,
         SORT_ORDER.MOST_RECENTLY_VALIDATED,
-      ]),
+      ),
     }).required(),
   },
 

--- a/src/controllers/validation/locations.js
+++ b/src/controllers/validation/locations.js
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 import { SORT_OPTIONS, SORT_ORDER } from '../sort-by';
+import config from '../../config';
 
 const updateMetadataSchema = Joi.object().keys({
   source: Joi.string(),
@@ -57,6 +58,29 @@ export default {
   getInfoBySlug: {
     params: Joi.object().keys({
       slug: Joi.string().required(),
+    }).required(),
+  },
+
+  findCatalog: {
+    query: Joi.object().keys({
+      latitude: Joi.number().required(),
+      longitude: Joi.number().required(),
+      radius: Joi.number()
+        .integer()
+        .positive()
+        .max(config.internalLocationCatalog.maxRadiusMeters)
+        .required(),
+      pageNumber: Joi.number()
+        .integer()
+        .min(0),
+      pageSize: Joi.number()
+        .integer()
+        .positive()
+        .max(config.internalLocationCatalog.maxPageSize),
+      sortBy: Joi.string().valid([
+        SORT_ORDER.NEARBY,
+        SORT_ORDER.MOST_RECENTLY_VALIDATED,
+      ]),
     }).required(),
   },
 

--- a/src/models/location.js
+++ b/src/models/location.js
@@ -668,5 +668,85 @@ module.exports = (sequelize, DataTypes, Op) => {
     };
   };
 
+  Location.findCatalog = async ({
+    position,
+    radius,
+    limit,
+    offset,
+    sortBy,
+  }) => {
+    let distance;
+    const whereConditions = [{
+      hidden_from_search: { [Op.or]: [false, null] },
+    }];
+
+    if (position) {
+      distance = sequelize.fn(
+        'ST_DistanceSphere',
+        sequelize.col('position'),
+        sequelize.literal(`ST_GeomFromGeoJSON('${JSON.stringify(position)}')`),
+      );
+    }
+
+    if (position && radius) {
+      whereConditions.push(sequelize.where(distance, { [Op.lte]: radius }));
+    }
+
+    let order;
+    if (position && (!sortBy || sortBy === SORT_ORDER.NEARBY)) {
+      order = [[distance, 'ASC'], ['id', 'ASC']];
+    } else {
+      order = [['last_validated_at', 'DESC'], ['id', 'ASC']];
+    }
+
+    const where = sequelize.and(...whereConditions);
+    const include = [
+      {
+        model: sequelize.models.Organization,
+        attributes: ['id', 'name'],
+      },
+      {
+        model: sequelize.models.PhysicalAddress,
+        attributes: [
+          'id',
+          'address_1',
+          'city',
+          'region',
+          'state_province',
+          'postal_code',
+          'country',
+        ],
+      },
+    ];
+
+    const totalNumLocations = await Location.count({
+      where,
+      distinct: true,
+      col: 'Location.id',
+    });
+
+    const locations = await Location.findAll({
+      attributes: [
+        'id',
+        'name',
+        'slug',
+        'description',
+        'additional_info',
+        'last_validated_at',
+        'position',
+      ],
+      where,
+      include,
+      order,
+      limit,
+      offset,
+    });
+
+    return {
+      locations,
+      totalNumLocations,
+    };
+  };
+
   return Location;
 };

--- a/src/models/location.js
+++ b/src/models/location.js
@@ -725,6 +725,23 @@ module.exports = (sequelize, DataTypes, Op) => {
       col: 'Location.id',
     });
 
+    const pageRows = await Location.findAll({
+      attributes: ['id'],
+      where,
+      order,
+      limit,
+      offset,
+      raw: true,
+    });
+
+    const locationIds = pageRows.map(location => location.id);
+    if (!locationIds.length) {
+      return {
+        locations: [],
+        totalNumLocations,
+      };
+    }
+
     const locations = await Location.findAll({
       attributes: [
         'id',
@@ -735,12 +752,15 @@ module.exports = (sequelize, DataTypes, Op) => {
         'last_validated_at',
         'position',
       ],
-      where,
+      where: {
+        id: { [Op.in]: locationIds },
+      },
       include,
-      order,
-      limit,
-      offset,
     });
+
+    const locationPositionById = new Map(locationIds.map((id, index) => [id, index]));
+    locations.sort((left, right) =>
+      locationPositionById.get(left.id) - locationPositionById.get(right.id));
 
     return {
       locations,

--- a/src/routes.js
+++ b/src/routes.js
@@ -23,6 +23,7 @@ export default (app) => {
   app.get('/organizations/:organizationId/locations', organizations.getLocations);
 
   app.get('/locations', locations.find);
+  app.get('/locations/catalog', locations.findCatalog);
 
   app.post('/locations/suggestions', locations.suggestNew);
   app.get('/locations-by-slug/:slug', locations.getInfoBySlug);

--- a/src/services/internal-location-catalog-auth.js
+++ b/src/services/internal-location-catalog-auth.js
@@ -1,0 +1,204 @@
+import crypto from 'crypto';
+import axios from 'axios';
+import config from '../config';
+import { AuthError, ForbiddenError } from '../utils/errors';
+
+const JWKS_CACHE_TTL_MS = 10 * 60 * 1000;
+const COGNITO_ISSUER_RE = /^https:\/\/cognito-idp\.[a-z0-9-]+\.amazonaws\.com\/[a-z0-9_-]+$/i;
+const SUPPORTED_TOKEN_USES = new Set(['id', 'access']);
+const jwksCache = new Map();
+const tokenCache = new Map();
+
+function decodeBase64UrlBuffer(value) {
+  const normalized = String(value || '')
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  return Buffer.from(padded, 'base64');
+}
+
+function decodeBase64UrlJson(value) {
+  try {
+    return JSON.parse(decodeBase64UrlBuffer(value).toString('utf8'));
+  } catch (error) {
+    throw new AuthError('Malformed bearer token');
+  }
+}
+
+function parseJwt(token) {
+  const parts = String(token || '').split('.');
+  if (parts.length !== 3) {
+    throw new AuthError('Malformed bearer token');
+  }
+  return {
+    header: decodeBase64UrlJson(parts[0]),
+    payload: decodeBase64UrlJson(parts[1]),
+    signingInput: `${parts[0]}.${parts[1]}`,
+    signature: decodeBase64UrlBuffer(parts[2]),
+  };
+}
+
+function normalizeHost(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/:\d+$/, '');
+}
+
+function extractRequestHost(value) {
+  if (!value) return null;
+  try {
+    const parsedUrl = new URL(value);
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      return null;
+    }
+    return normalizeHost(parsedUrl.hostname);
+  } catch (error) {
+    if (String(value).includes('://')) {
+      return null;
+    }
+    return normalizeHost(value);
+  }
+}
+
+function isAllowedHost(host, allowedHosts) {
+  return allowedHosts.some((allowedHost) => {
+    const normalizedAllowedHost = normalizeHost(allowedHost);
+    if (!normalizedAllowedHost) return false;
+    if (normalizedAllowedHost.startsWith('*.')) {
+      const suffix = normalizedAllowedHost.slice(1);
+      return host.endsWith(suffix);
+    }
+    return host === normalizedAllowedHost;
+  });
+}
+
+function assertAllowedRequestHost(req) {
+  const allowedHosts = config.internalLocationCatalog.allowedOriginHosts || [];
+  if (!allowedHosts.length) return;
+  const requestHosts = [
+    extractRequestHost(req.headers.origin),
+    extractRequestHost(req.headers.referer || req.headers.referrer),
+  ].filter(Boolean);
+  if (!requestHosts.length) return;
+  if (requestHosts.some(host => isAllowedHost(host, allowedHosts))) return;
+  throw new ForbiddenError('Origin not allowed for internal location catalog');
+}
+
+async function fetchIssuerJwks(issuer) {
+  const cached = jwksCache.get(issuer);
+  if (cached && cached.keysByKid && Date.now() - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return cached.keysByKid;
+  }
+  if (cached && cached.promise) {
+    return cached.promise;
+  }
+  const request = axios
+    .get(`${issuer}/.well-known/jwks.json`, { timeout: 5000 })
+    .then(({ data }) => {
+      if (!data || !Array.isArray(data.keys)) {
+        throw new AuthError('Unable to load Cognito signing keys');
+      }
+      const keysByKid = new Map();
+      data.keys.forEach((key) => {
+        if (key && key.kid) {
+          keysByKid.set(key.kid, key);
+        }
+      });
+      jwksCache.set(issuer, {
+        fetchedAt: Date.now(),
+        keysByKid,
+        promise: null,
+      });
+      return keysByKid;
+    })
+    .catch((error) => {
+      jwksCache.delete(issuer);
+      if (error instanceof AuthError) {
+        throw error;
+      }
+      throw new AuthError('Unable to verify bearer token');
+    });
+  jwksCache.set(issuer, { fetchedAt: 0, keysByKid: null, promise: request });
+  return request;
+}
+
+function verifyJwtSignature(parsedToken, jwk) {
+  if (!jwk || jwk.kty !== 'RSA') {
+    throw new AuthError('Unsupported Cognito signing key');
+  }
+  const verifier = crypto.createVerify('RSA-SHA256');
+  verifier.update(parsedToken.signingInput);
+  verifier.end();
+  return verifier.verify(
+    crypto.createPublicKey({ key: jwk, format: 'jwk' }),
+    parsedToken.signature,
+  );
+}
+
+function assertTokenClaims(payload) {
+  const expiresAtMs = Number(payload.exp) * 1000;
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+    throw new AuthError('Bearer token has expired');
+  }
+  const issuer = String(payload.iss || '').trim();
+  if (!issuer || !COGNITO_ISSUER_RE.test(issuer)) {
+    throw new AuthError('Bearer token issuer is not allowed');
+  }
+  if (config.cognito.userPoolIssuer && issuer !== config.cognito.userPoolIssuer) {
+    throw new AuthError('Bearer token issuer is not allowed');
+  }
+  const tokenUse = String(payload.token_use || '').trim();
+  if (!SUPPORTED_TOKEN_USES.has(tokenUse)) {
+    throw new AuthError('Unsupported Cognito token type');
+  }
+  return expiresAtMs;
+}
+
+function getBearerToken(req) {
+  const authorization = req.headers.authorization || req.headers.Authorization;
+  if (typeof authorization !== 'string') return null;
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+async function verifyCognitoJwt(token) {
+  const cached = tokenCache.get(token);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.payload;
+  }
+
+  const parsedToken = parseJwt(token);
+  const expiresAt = assertTokenClaims(parsedToken.payload);
+  const keysByKid = await fetchIssuerJwks(parsedToken.payload.iss);
+  const jwk = keysByKid.get(parsedToken.header.kid);
+  if (!jwk) {
+    throw new AuthError('Unable to verify bearer token');
+  }
+  if (!verifyJwtSignature(parsedToken, jwk)) {
+    throw new AuthError('Unable to verify bearer token');
+  }
+
+  tokenCache.set(token, {
+    expiresAt,
+    payload: parsedToken.payload,
+  });
+
+  return parsedToken.payload;
+}
+
+export default async function authorizeInternalLocationCatalogRequest(req) {
+  const bearerToken = getBearerToken(req);
+  if (!bearerToken) {
+    throw new AuthError('Missing bearer token');
+  }
+  assertAllowedRequestHost(req);
+  if (process.env.NODE_ENV === 'test') {
+    return {
+      sub: 'test-user',
+      token_use: 'test',
+      iss: config.cognito.userPoolIssuer,
+    };
+  }
+  return verifyCognitoJwt(bearerToken);
+}

--- a/src/services/internal-location-catalog-auth.js
+++ b/src/services/internal-location-catalog-auth.js
@@ -288,14 +288,6 @@ export default async function authorizeInternalLocationCatalogRequest(req) {
     throw new AuthError('Missing bearer token');
   }
   assertAllowedRequestOrigin(req);
-  if (process.env.NODE_ENV === 'test' && bearerToken === 'test-internal-token') {
-    return {
-      sub: 'test-user',
-      token_use: 'test',
-      iss: config.cognito.userPoolIssuer,
-      aud: (config.internalLocationCatalog.allowedClientIds || [])[0] || null,
-    };
-  }
   const payload = await verifyCognitoJwt(bearerToken);
   assertCatalogAuthorizationClaims(payload);
   return payload;

--- a/src/services/internal-location-catalog-auth.js
+++ b/src/services/internal-location-catalog-auth.js
@@ -45,6 +45,13 @@ function normalizeHost(value) {
     .replace(/:\d+$/, '');
 }
 
+function normalizeOriginPattern(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\/$/, '');
+}
+
 function normalizeValues(values) {
   return values
     .map(value => String(value || '').trim())
@@ -64,19 +71,19 @@ function getClaimValues(value) {
   return normalizeValues([value]);
 }
 
-function extractRequestHost(value) {
+function extractRequestOrigin(value) {
   if (!value) return null;
+  const rawValue = String(value).trim();
+  if (!rawValue) return null;
+  if (rawValue.toLowerCase() === 'null') return 'null';
   try {
-    const parsedUrl = new URL(value);
-    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    const parsedUrl = new URL(rawValue);
+    if (!parsedUrl.protocol || !parsedUrl.host) {
       return null;
     }
-    return normalizeHost(parsedUrl.hostname);
+    return `${parsedUrl.protocol}//${parsedUrl.host}`.toLowerCase();
   } catch (error) {
-    if (String(value).includes('://')) {
-      return null;
-    }
-    return normalizeHost(value);
+    return normalizeOriginPattern(rawValue);
   }
 }
 
@@ -92,19 +99,56 @@ function isAllowedHost(host, allowedHosts) {
   });
 }
 
-function assertAllowedRequestHost(req) {
+function isAllowedOrigin(origin, allowedOriginPatterns) {
+  return allowedOriginPatterns.some((allowedOriginPattern) => {
+    const normalizedAllowedOriginPattern = normalizeOriginPattern(allowedOriginPattern);
+    if (!normalizedAllowedOriginPattern) return false;
+    if (normalizedAllowedOriginPattern.endsWith('*')) {
+      return origin.startsWith(normalizedAllowedOriginPattern.slice(0, -1));
+    }
+    return origin === normalizedAllowedOriginPattern;
+  });
+}
+
+function assertAllowedRequestOrigin(req) {
   const allowedHosts = config.internalLocationCatalog.allowedOriginHosts || [];
-  if (!allowedHosts.length) return;
-  const requestHosts = [
-    extractRequestHost(req.headers.origin),
-    extractRequestHost(req.headers.referer || req.headers.referrer),
-  ].filter(Boolean);
-  if (!requestHosts.length) return;
+  const allowedOriginPatterns = config.internalLocationCatalog.allowedOriginPatterns || [];
+  if (!allowedHosts.length && !allowedOriginPatterns.length) return;
+
+  const requestOrigin = extractRequestOrigin(req.headers.origin);
+  const requestRefererOrigin = extractRequestOrigin(req.headers.referer || req.headers.referrer);
+  const requestOrigins = [requestOrigin, requestRefererOrigin].filter(Boolean);
+  if (!requestOrigins.length) {
+    throw new ForbiddenError('Origin not allowed for internal location catalog');
+  }
+
+  const requestHosts = requestOrigins
+    .map((origin) => {
+      try {
+        const parsedOrigin = new URL(origin);
+        if (!['http:', 'https:'].includes(parsedOrigin.protocol)) {
+          return null;
+        }
+        return normalizeHost(parsedOrigin.hostname);
+      } catch (error) {
+        return null;
+      }
+    })
+    .filter(Boolean);
+
   if (requestHosts.some(host => isAllowedHost(host, allowedHosts))) return;
+  if (requestOrigins.some(origin => isAllowedOrigin(origin, allowedOriginPatterns))) return;
   throw new ForbiddenError('Origin not allowed for internal location catalog');
 }
 
+function assertCatalogAuthorizationConfigured() {
+  if (!config.cognito.userPoolIssuer) {
+    throw new ForbiddenError('Internal location catalog authorization is not configured');
+  }
+}
+
 function assertCatalogAuthorizationClaims(payload) {
+  assertCatalogAuthorizationConfigured();
   const allowedClientIds = normalizeValues(
     config.internalLocationCatalog.allowedClientIds || [],
   );
@@ -243,7 +287,7 @@ export default async function authorizeInternalLocationCatalogRequest(req) {
   if (!bearerToken) {
     throw new AuthError('Missing bearer token');
   }
-  assertAllowedRequestHost(req);
+  assertAllowedRequestOrigin(req);
   if (process.env.NODE_ENV === 'test' && bearerToken === 'test-internal-token') {
     return {
       sub: 'test-user',

--- a/src/services/internal-location-catalog-auth.js
+++ b/src/services/internal-location-catalog-auth.js
@@ -45,6 +45,25 @@ function normalizeHost(value) {
     .replace(/:\d+$/, '');
 }
 
+function normalizeValues(values) {
+  return values
+    .map(value => String(value || '').trim())
+    .filter(Boolean);
+}
+
+function getClaimValues(value) {
+  if (Array.isArray(value)) {
+    return normalizeValues(value);
+  }
+  if (value == null) {
+    return [];
+  }
+  if (typeof value === 'string' && value.includes(',')) {
+    return normalizeValues(value.split(','));
+  }
+  return normalizeValues([value]);
+}
+
 function extractRequestHost(value) {
   if (!value) return null;
   try {
@@ -83,6 +102,38 @@ function assertAllowedRequestHost(req) {
   if (!requestHosts.length) return;
   if (requestHosts.some(host => isAllowedHost(host, allowedHosts))) return;
   throw new ForbiddenError('Origin not allowed for internal location catalog');
+}
+
+function assertCatalogAuthorizationClaims(payload) {
+  const allowedClientIds = normalizeValues(
+    config.internalLocationCatalog.allowedClientIds || [],
+  );
+  const allowedGroupNames = normalizeValues(
+    config.internalLocationCatalog.allowedGroupNames || [],
+  );
+  if (!allowedClientIds.length && !allowedGroupNames.length) {
+    throw new ForbiddenError('Internal location catalog authorization is not configured');
+  }
+
+  if (allowedClientIds.length) {
+    const tokenClientIds = getClaimValues(payload.client_id)
+      .concat(getClaimValues(payload.aud))
+      .concat(getClaimValues(payload.azp));
+    const hasAllowedClientId = tokenClientIds.some(tokenClientId =>
+      allowedClientIds.includes(tokenClientId));
+    if (!hasAllowedClientId) {
+      throw new ForbiddenError('Bearer token client is not allowed for internal location catalog');
+    }
+  }
+
+  if (allowedGroupNames.length) {
+    const tokenGroups = getClaimValues(payload['cognito:groups']);
+    const hasAllowedGroup = tokenGroups.some(groupName =>
+      allowedGroupNames.includes(groupName));
+    if (!hasAllowedGroup) {
+      throw new ForbiddenError('Bearer token group is not allowed for internal location catalog');
+    }
+  }
 }
 
 async function fetchIssuerJwks(issuer) {
@@ -193,12 +244,15 @@ export default async function authorizeInternalLocationCatalogRequest(req) {
     throw new AuthError('Missing bearer token');
   }
   assertAllowedRequestHost(req);
-  if (process.env.NODE_ENV === 'test') {
+  if (process.env.NODE_ENV === 'test' && bearerToken === 'test-internal-token') {
     return {
       sub: 'test-user',
       token_use: 'test',
       iss: config.cognito.userPoolIssuer,
+      aud: (config.internalLocationCatalog.allowedClientIds || [])[0] || null,
     };
   }
-  return verifyCognitoJwt(bearerToken);
+  const payload = await verifyCognitoJwt(bearerToken);
+  assertCatalogAuthorizationClaims(payload);
+  return payload;
 }

--- a/src/services/internal-location-catalog-auth.js
+++ b/src/services/internal-location-catalog-auth.js
@@ -7,7 +7,6 @@ const JWKS_CACHE_TTL_MS = 10 * 60 * 1000;
 const COGNITO_ISSUER_RE = /^https:\/\/cognito-idp\.[a-z0-9-]+\.amazonaws\.com\/[a-z0-9_-]+$/i;
 const SUPPORTED_TOKEN_USES = new Set(['id', 'access']);
 const jwksCache = new Map();
-const tokenCache = new Map();
 
 function decodeBase64UrlBuffer(value) {
   const normalized = String(value || '')
@@ -181,13 +180,8 @@ function getBearerToken(req) {
 }
 
 async function verifyCognitoJwt(token) {
-  const cached = tokenCache.get(token);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.payload;
-  }
-
   const parsedToken = parseJwt(token);
-  const expiresAt = assertTokenClaims(parsedToken.payload);
+  assertTokenClaims(parsedToken.payload);
   const keysByKid = await fetchIssuerJwks(parsedToken.payload.iss);
   const jwk = keysByKid.get(parsedToken.header.kid);
   if (!jwk) {
@@ -196,11 +190,6 @@ async function verifyCognitoJwt(token) {
   if (!verifyJwtSignature(parsedToken, jwk)) {
     throw new AuthError('Unable to verify bearer token');
   }
-
-  tokenCache.set(token, {
-    expiresAt,
-    payload: parsedToken.payload,
-  });
 
   return parsedToken.payload;
 }

--- a/src/services/internal-location-catalog-auth.js
+++ b/src/services/internal-location-catalog-auth.js
@@ -38,20 +38,6 @@ function parseJwt(token) {
   };
 }
 
-function normalizeHost(value) {
-  return String(value || '')
-    .trim()
-    .toLowerCase()
-    .replace(/:\d+$/, '');
-}
-
-function normalizeOriginPattern(value) {
-  return String(value || '')
-    .trim()
-    .toLowerCase()
-    .replace(/\/$/, '');
-}
-
 function normalizeValues(values) {
   return values
     .map(value => String(value || '').trim())
@@ -71,112 +57,49 @@ function getClaimValues(value) {
   return normalizeValues([value]);
 }
 
-function extractRequestOrigin(value) {
-  if (!value) return null;
-  const rawValue = String(value).trim();
-  if (!rawValue) return null;
-  if (rawValue.toLowerCase() === 'null') return 'null';
-  try {
-    const parsedUrl = new URL(rawValue);
-    if (!parsedUrl.protocol || !parsedUrl.host) {
-      return null;
-    }
-    return `${parsedUrl.protocol}//${parsedUrl.host}`.toLowerCase();
-  } catch (error) {
-    return normalizeOriginPattern(rawValue);
-  }
-}
-
-function isAllowedHost(host, allowedHosts) {
-  return allowedHosts.some((allowedHost) => {
-    const normalizedAllowedHost = normalizeHost(allowedHost);
-    if (!normalizedAllowedHost) return false;
-    if (normalizedAllowedHost.startsWith('*.')) {
-      const suffix = normalizedAllowedHost.slice(1);
-      return host.endsWith(suffix);
-    }
-    return host === normalizedAllowedHost;
-  });
-}
-
-function isAllowedOrigin(origin, allowedOriginPatterns) {
-  return allowedOriginPatterns.some((allowedOriginPattern) => {
-    const normalizedAllowedOriginPattern = normalizeOriginPattern(allowedOriginPattern);
-    if (!normalizedAllowedOriginPattern) return false;
-    if (normalizedAllowedOriginPattern.endsWith('*')) {
-      return origin.startsWith(normalizedAllowedOriginPattern.slice(0, -1));
-    }
-    return origin === normalizedAllowedOriginPattern;
-  });
-}
-
-function assertAllowedRequestOrigin(req) {
-  const allowedHosts = config.internalLocationCatalog.allowedOriginHosts || [];
-  const allowedOriginPatterns = config.internalLocationCatalog.allowedOriginPatterns || [];
-  if (!allowedHosts.length && !allowedOriginPatterns.length) return;
-
-  const requestOrigin = extractRequestOrigin(req.headers.origin);
-  const requestRefererOrigin = extractRequestOrigin(req.headers.referer || req.headers.referrer);
-  const requestOrigins = [requestOrigin, requestRefererOrigin].filter(Boolean);
-  if (!requestOrigins.length) {
-    throw new ForbiddenError('Origin not allowed for internal location catalog');
-  }
-
-  const requestHosts = requestOrigins
-    .map((origin) => {
-      try {
-        const parsedOrigin = new URL(origin);
-        if (!['http:', 'https:'].includes(parsedOrigin.protocol)) {
-          return null;
-        }
-        return normalizeHost(parsedOrigin.hostname);
-      } catch (error) {
-        return null;
-      }
-    })
-    .filter(Boolean);
-
-  if (requestHosts.some(host => isAllowedHost(host, allowedHosts))) return;
-  if (requestOrigins.some(origin => isAllowedOrigin(origin, allowedOriginPatterns))) return;
-  throw new ForbiddenError('Origin not allowed for internal location catalog');
-}
-
+// Internal catalog access is granted only from verified Cognito claims.
 function assertCatalogAuthorizationConfigured() {
-  if (!config.cognito.userPoolIssuer) {
-    throw new ForbiddenError('Internal location catalog authorization is not configured');
-  }
-}
-
-function assertCatalogAuthorizationClaims(payload) {
-  assertCatalogAuthorizationConfigured();
   const allowedClientIds = normalizeValues(
     config.internalLocationCatalog.allowedClientIds || [],
   );
   const allowedGroupNames = normalizeValues(
     config.internalLocationCatalog.allowedGroupNames || [],
   );
-  if (!allowedClientIds.length && !allowedGroupNames.length) {
+
+  if (
+    !config.cognito.userPoolIssuer
+    || !allowedClientIds.length
+    || !allowedGroupNames.length
+  ) {
     throw new ForbiddenError('Internal location catalog authorization is not configured');
   }
 
-  if (allowedClientIds.length) {
-    const tokenClientIds = getClaimValues(payload.client_id)
-      .concat(getClaimValues(payload.aud))
-      .concat(getClaimValues(payload.azp));
-    const hasAllowedClientId = tokenClientIds.some(tokenClientId =>
-      allowedClientIds.includes(tokenClientId));
-    if (!hasAllowedClientId) {
-      throw new ForbiddenError('Bearer token client is not allowed for internal location catalog');
-    }
+  return {
+    allowedClientIds,
+    allowedGroupNames,
+  };
+}
+
+function assertCatalogAuthorizationClaims(payload) {
+  const {
+    allowedClientIds,
+    allowedGroupNames,
+  } = assertCatalogAuthorizationConfigured();
+
+  const tokenClientIds = getClaimValues(payload.client_id)
+    .concat(getClaimValues(payload.aud))
+    .concat(getClaimValues(payload.azp));
+  const hasAllowedClientId = tokenClientIds.some(tokenClientId =>
+    allowedClientIds.includes(tokenClientId));
+  if (!hasAllowedClientId) {
+    throw new ForbiddenError('Bearer token client is not allowed for internal location catalog');
   }
 
-  if (allowedGroupNames.length) {
-    const tokenGroups = getClaimValues(payload['cognito:groups']);
-    const hasAllowedGroup = tokenGroups.some(groupName =>
-      allowedGroupNames.includes(groupName));
-    if (!hasAllowedGroup) {
-      throw new ForbiddenError('Bearer token group is not allowed for internal location catalog');
-    }
+  const tokenGroups = getClaimValues(payload['cognito:groups']);
+  const hasAllowedGroup = tokenGroups.some(groupName =>
+    allowedGroupNames.includes(groupName));
+  if (!hasAllowedGroup) {
+    throw new ForbiddenError('Bearer token group is not allowed for internal location catalog');
   }
 }
 
@@ -287,7 +210,6 @@ export default async function authorizeInternalLocationCatalogRequest(req) {
   if (!bearerToken) {
     throw new AuthError('Missing bearer token');
   }
-  assertAllowedRequestOrigin(req);
   const payload = await verifyCognitoJwt(bearerToken);
   assertCatalogAuthorizationClaims(payload);
   return payload;

--- a/src/services/internal-location-catalog-cors.js
+++ b/src/services/internal-location-catalog-cors.js
@@ -1,0 +1,99 @@
+import cors from 'cors';
+import config from '../config';
+
+export const exposedHeaders = [
+  'Pagination-Count',
+  'Total-Count',
+  'Page-Number',
+  'Page-Size',
+  'Has-More',
+  'Next-Page',
+];
+
+function normalizeHost(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/:\d+$/, '');
+}
+
+function normalizeOriginPattern(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\/$/, '');
+}
+
+function extractRequestOrigin(value) {
+  if (!value) return null;
+  const rawValue = String(value).trim();
+  if (!rawValue) return null;
+  if (rawValue.toLowerCase() === 'null') return 'null';
+  try {
+    const parsedUrl = new URL(rawValue);
+    if (!parsedUrl.protocol || !parsedUrl.host) {
+      return null;
+    }
+    return `${parsedUrl.protocol}//${parsedUrl.host}`.toLowerCase();
+  } catch (error) {
+    return normalizeOriginPattern(rawValue);
+  }
+}
+
+function isAllowedHost(host, allowedHosts) {
+  return allowedHosts.some((allowedHost) => {
+    const normalizedAllowedHost = normalizeHost(allowedHost);
+    if (!normalizedAllowedHost) return false;
+    if (normalizedAllowedHost.startsWith('*.')) {
+      const suffix = normalizedAllowedHost.slice(1);
+      return host.endsWith(suffix);
+    }
+    return host === normalizedAllowedHost;
+  });
+}
+
+function isAllowedOrigin(origin, allowedOriginPatterns) {
+  return allowedOriginPatterns.some((allowedOriginPattern) => {
+    const normalizedAllowedOriginPattern = normalizeOriginPattern(allowedOriginPattern);
+    if (!normalizedAllowedOriginPattern) return false;
+    if (normalizedAllowedOriginPattern.endsWith('*')) {
+      return origin.startsWith(normalizedAllowedOriginPattern.slice(0, -1));
+    }
+    return origin === normalizedAllowedOriginPattern;
+  });
+}
+
+// Browser origin allowlists are only used for CORS responses.
+export function isAllowedInternalLocationCatalogOrigin(value) {
+  const allowedHosts = config.internalLocationCatalog.allowedOriginHosts || [];
+  const allowedOriginPatterns = config.internalLocationCatalog.allowedOriginPatterns || [];
+  if (!allowedHosts.length && !allowedOriginPatterns.length) return true;
+
+  const requestOrigin = extractRequestOrigin(value);
+  if (!requestOrigin) return false;
+
+  try {
+    const parsedOrigin = new URL(requestOrigin);
+    if (['http:', 'https:'].includes(parsedOrigin.protocol)) {
+      return isAllowedHost(parsedOrigin.hostname, allowedHosts)
+        || isAllowedOrigin(requestOrigin, allowedOriginPatterns);
+    }
+  } catch (error) {
+    return isAllowedOrigin(requestOrigin, allowedOriginPatterns);
+  }
+
+  return isAllowedOrigin(requestOrigin, allowedOriginPatterns);
+}
+
+export const publicApiCors = cors({ exposedHeaders });
+
+export const internalLocationCatalogCors = cors({
+  exposedHeaders,
+  origin(origin, callback) {
+    if (!origin) {
+      callback(null, true);
+      return;
+    }
+    callback(null, isAllowedInternalLocationCatalogOrigin(origin));
+  },
+});

--- a/test/controllers/locations-validation.test.js
+++ b/test/controllers/locations-validation.test.js
@@ -1,0 +1,38 @@
+const Joi = require('joi');
+
+const validateFindCatalog = (query) => {
+  jest.resetModules();
+  const locationSchemas = require('../../src/controllers/validation/locations').default;
+  return Joi.validate({ query }, locationSchemas.findCatalog, { allowUnknown: true });
+};
+
+describe('location catalog validation', () => {
+  it('accepts supported sortBy values', () => {
+    const nearbyResult = validateFindCatalog({
+      latitude: 40.7,
+      longitude: -73.9,
+      radius: 1000,
+      sortBy: 'nearby',
+    });
+    const recentlyUpdatedResult = validateFindCatalog({
+      latitude: 40.7,
+      longitude: -73.9,
+      radius: 1000,
+      sortBy: 'recentlyUpdated',
+    });
+
+    expect(nearbyResult.error).toBeNull();
+    expect(recentlyUpdatedResult.error).toBeNull();
+  });
+
+  it('rejects unsupported sortBy values', () => {
+    const result = validateFindCatalog({
+      latitude: 40.7,
+      longitude: -73.9,
+      radius: 1000,
+      sortBy: 'mostServices',
+    });
+
+    expect(result.error).not.toBeNull();
+  });
+});

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { AuthError, ForbiddenError } from '../../src/utils/errors';
+import { AuthError } from '../../src/utils/errors';
 
 const mockAuthorizeInternalLocationCatalogRequest = jest.fn();
 
@@ -211,20 +211,7 @@ describe('find locations', () => {
       if (typeof authorization !== 'string' || !authorization.match(/^Bearer\s+.+$/i)) {
         throw new AuthError('Missing bearer token');
       }
-
-      const requestOrigin = req.headers.origin;
-      if (!requestOrigin) {
-        throw new ForbiddenError('Origin not allowed for internal location catalog');
-      }
-
-      if (
-        requestOrigin !== 'https://sheets.doobneek.org'
-        && requestOrigin !== 'chrome-extension://abcdefghijklmnop'
-      ) {
-        throw new ForbiddenError('Origin not allowed for internal location catalog');
-      }
-
-      return { sub: 'test-user', aud: 'allowed-client-id' };
+      return { sub: 'test-user', aud: 'allowed-client-id', 'cognito:groups': ['InternalCatalogUsers'] };
     });
 
     await setupData();
@@ -1138,19 +1125,7 @@ describe('find locations', () => {
         })
         .expect(401));
 
-    it('should reject authenticated browser requests from disallowed origins', () =>
-      request(app)
-        .get('/locations/catalog')
-        .set('Authorization', 'Bearer mocked-internal-token')
-        .set('Origin', 'https://example.com')
-        .query({
-          latitude: originLatitude,
-          longitude: originLongitude,
-          radius: 20000,
-        })
-        .expect(403));
-
-    it('should reject authenticated requests with no origin context', () =>
+    it('should allow authenticated requests with no browser origin context', () =>
       request(app)
         .get('/locations/catalog')
         .set('Authorization', 'Bearer mocked-internal-token')
@@ -1158,8 +1133,14 @@ describe('find locations', () => {
           latitude: originLatitude,
           longitude: originLongitude,
           radius: 20000,
+          pageNumber: 0,
+          pageSize: 1,
         })
-        .expect(403));
+        .expect(200)
+        .then((res) => {
+          expect(res.headers['total-count']).toBe('3');
+          expect(res.body).toHaveLength(1);
+        }));
 
     it('should allow authenticated extension requests from allowed extension origins', () =>
       request(app)

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -1117,7 +1117,18 @@ describe('find locations', () => {
         })
         .expect(403));
 
-    it('should allow authenticated extension requests without enforcing the web host allowlist', () =>
+    it('should reject authenticated requests with no origin context', () =>
+      request(app)
+        .get('/locations/catalog')
+        .set('Authorization', 'Bearer test-internal-token')
+        .query({
+          latitude: originLatitude,
+          longitude: originLongitude,
+          radius: 20000,
+        })
+        .expect(403));
+
+    it('should allow authenticated extension requests from allowed extension origins', () =>
       request(app)
         .get('/locations/catalog')
         .set('Authorization', 'Bearer test-internal-token')
@@ -1139,6 +1150,7 @@ describe('find locations', () => {
       request(app)
         .get('/locations/catalog')
         .set('Authorization', 'Bearer test-internal-token')
+        .set('Origin', 'https://sheets.doobneek.org')
         .query({
           latitude: originLatitude,
           longitude: originLongitude,
@@ -1174,6 +1186,7 @@ describe('find locations', () => {
       request(app)
         .get('/locations/catalog')
         .set('Authorization', 'Bearer test-internal-token')
+        .set('Origin', 'https://sheets.doobneek.org')
         .query({
           latitude: originLatitude,
           longitude: originLongitude,

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -2,6 +2,15 @@
  * @jest-environment node
  */
 
+import { AuthError, ForbiddenError } from '../../src/utils/errors';
+
+const mockAuthorizeInternalLocationCatalogRequest = jest.fn();
+
+jest.mock('../../src/services/internal-location-catalog-auth', () => ({
+  __esModule: true,
+  default: (...args) => mockAuthorizeInternalLocationCatalogRequest(...args),
+}));
+
 import request from 'supertest';
 import qs from 'qs';
 import app from '../../src/app';
@@ -195,7 +204,31 @@ describe('find locations', () => {
     expect(returnedLocations).toEqual([]);
   };
 
-  beforeEach(setupData);
+  beforeEach(async () => {
+    mockAuthorizeInternalLocationCatalogRequest.mockReset();
+    mockAuthorizeInternalLocationCatalogRequest.mockImplementation(async (req) => {
+      const authorization = req.headers.authorization || req.headers.Authorization;
+      if (typeof authorization !== 'string' || !authorization.match(/^Bearer\s+.+$/i)) {
+        throw new AuthError('Missing bearer token');
+      }
+
+      const requestOrigin = req.headers.origin;
+      if (!requestOrigin) {
+        throw new ForbiddenError('Origin not allowed for internal location catalog');
+      }
+
+      if (
+        requestOrigin !== 'https://sheets.doobneek.org'
+        && requestOrigin !== 'chrome-extension://abcdefghijklmnop'
+      ) {
+        throw new ForbiddenError('Origin not allowed for internal location catalog');
+      }
+
+      return { sub: 'test-user', aud: 'allowed-client-id' };
+    });
+
+    await setupData();
+  });
   afterAll(clearData);
 
   it('should return locations within a given radius of a given position', () =>
@@ -1108,7 +1141,7 @@ describe('find locations', () => {
     it('should reject authenticated browser requests from disallowed origins', () =>
       request(app)
         .get('/locations/catalog')
-        .set('Authorization', 'Bearer test-internal-token')
+        .set('Authorization', 'Bearer mocked-internal-token')
         .set('Origin', 'https://example.com')
         .query({
           latitude: originLatitude,
@@ -1120,7 +1153,7 @@ describe('find locations', () => {
     it('should reject authenticated requests with no origin context', () =>
       request(app)
         .get('/locations/catalog')
-        .set('Authorization', 'Bearer test-internal-token')
+        .set('Authorization', 'Bearer mocked-internal-token')
         .query({
           latitude: originLatitude,
           longitude: originLongitude,
@@ -1131,7 +1164,7 @@ describe('find locations', () => {
     it('should allow authenticated extension requests from allowed extension origins', () =>
       request(app)
         .get('/locations/catalog')
-        .set('Authorization', 'Bearer test-internal-token')
+        .set('Authorization', 'Bearer mocked-internal-token')
         .set('Origin', 'chrome-extension://abcdefghijklmnop')
         .query({
           latitude: originLatitude,
@@ -1149,7 +1182,7 @@ describe('find locations', () => {
     it('should return a slim paginated catalog for authenticated internal users', () =>
       request(app)
         .get('/locations/catalog')
-        .set('Authorization', 'Bearer test-internal-token')
+        .set('Authorization', 'Bearer mocked-internal-token')
         .set('Origin', 'https://sheets.doobneek.org')
         .query({
           latitude: originLatitude,
@@ -1185,7 +1218,7 @@ describe('find locations', () => {
     it('should return the final page without a next-page header', () =>
       request(app)
         .get('/locations/catalog')
-        .set('Authorization', 'Bearer test-internal-token')
+        .set('Authorization', 'Bearer mocked-internal-token')
         .set('Origin', 'https://sheets.doobneek.org')
         .query({
           latitude: originLatitude,

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -1093,4 +1093,108 @@ describe('find locations', () => {
         .query(qs.stringify({ zipcodes: [] }))
         .then(res => expect(res.body.length).toBeGreaterThan(0)));
   });
+
+  describe('internal location catalog', () => {
+    it('should require a bearer token', () =>
+      request(app)
+        .get('/locations/catalog')
+        .query({
+          latitude: originLatitude,
+          longitude: originLongitude,
+          radius: 20000,
+        })
+        .expect(401));
+
+    it('should reject authenticated browser requests from disallowed origins', () =>
+      request(app)
+        .get('/locations/catalog')
+        .set('Authorization', 'Bearer test-internal-token')
+        .set('Origin', 'https://example.com')
+        .query({
+          latitude: originLatitude,
+          longitude: originLongitude,
+          radius: 20000,
+        })
+        .expect(403));
+
+    it('should allow authenticated extension requests without enforcing the web host allowlist', () =>
+      request(app)
+        .get('/locations/catalog')
+        .set('Authorization', 'Bearer test-internal-token')
+        .set('Origin', 'chrome-extension://abcdefghijklmnop')
+        .query({
+          latitude: originLatitude,
+          longitude: originLongitude,
+          radius: 20000,
+          pageNumber: 0,
+          pageSize: 1,
+        })
+        .expect(200)
+        .then((res) => {
+          expect(res.headers['total-count']).toBe('3');
+          expect(res.body).toHaveLength(1);
+        }));
+
+    it('should return a slim paginated catalog for authenticated internal users', () =>
+      request(app)
+        .get('/locations/catalog')
+        .set('Authorization', 'Bearer test-internal-token')
+        .query({
+          latitude: originLatitude,
+          longitude: originLongitude,
+          radius: 20000,
+          pageNumber: 0,
+          pageSize: 2,
+        })
+        .expect(200)
+        .then((res) => {
+          expect(res.headers['total-count']).toBe('3');
+          expect(res.headers['pagination-count']).toBe('2');
+          expect(res.headers['page-number']).toBe('0');
+          expect(res.headers['page-size']).toBe('2');
+          expect(res.headers['has-more']).toBe('true');
+          expect(res.headers['next-page']).toBe('1');
+          expect(res.body).toHaveLength(2);
+          expect(res.body[0]).toEqual(expect.objectContaining({
+            id: primaryLocation.id,
+            name: primaryLocation.name,
+            org: organization.name,
+            Organization: expect.objectContaining({
+              id: organization.id,
+              name: organization.name,
+            }),
+          }));
+          expect(res.body[0]).not.toHaveProperty('Services');
+          expect(res.body[0]).not.toHaveProperty('EventRelatedInfos');
+          expect(res.body[0]).toHaveProperty('PhysicalAddresses');
+          expect(Array.isArray(res.body[0].PhysicalAddresses)).toBe(true);
+        }));
+
+    it('should return the final page without a next-page header', () =>
+      request(app)
+        .get('/locations/catalog')
+        .set('Authorization', 'Bearer test-internal-token')
+        .query({
+          latitude: originLatitude,
+          longitude: originLongitude,
+          radius: 20000,
+          pageNumber: 1,
+          pageSize: 2,
+        })
+        .expect(200)
+        .then((res) => {
+          expect(res.headers['total-count']).toBe('3');
+          expect(res.headers['pagination-count']).toBe('2');
+          expect(res.headers['page-number']).toBe('1');
+          expect(res.headers['page-size']).toBe('2');
+          expect(res.headers['has-more']).toBe('false');
+          expect(res.headers['next-page']).toBeUndefined();
+          expect(res.body).toHaveLength(1);
+          expect(res.body[0]).toEqual(expect.objectContaining({
+            id: farLocation.id,
+            name: farLocation.name,
+            org: organization.name,
+          }));
+        }));
+  });
 });

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -1196,6 +1196,51 @@ describe('find locations', () => {
           expect(Array.isArray(res.body[0].PhysicalAddresses)).toBe(true);
         }));
 
+    it('should paginate distinct locations when a location has multiple physical addresses', async () => {
+      await primaryLocation.createPhysicalAddress({
+        address_1: '124 W 50th St.',
+        city: 'New York',
+        state_province: 'NY',
+        postal_code: '10001',
+        country: 'US',
+      });
+
+      const firstPage = await request(app)
+        .get('/locations/catalog')
+        .set('Authorization', 'Bearer mocked-internal-token')
+        .set('Origin', 'https://sheets.doobneek.org')
+        .query({
+          latitude: originLatitude,
+          longitude: originLongitude,
+          radius: 20000,
+          pageNumber: 0,
+          pageSize: 1,
+        })
+        .expect(200);
+
+      const secondPage = await request(app)
+        .get('/locations/catalog')
+        .set('Authorization', 'Bearer mocked-internal-token')
+        .set('Origin', 'https://sheets.doobneek.org')
+        .query({
+          latitude: originLatitude,
+          longitude: originLongitude,
+          radius: 20000,
+          pageNumber: 1,
+          pageSize: 1,
+        })
+        .expect(200);
+
+      expect(firstPage.headers['total-count']).toBe('3');
+      expect(secondPage.headers['total-count']).toBe('3');
+      expect(firstPage.body).toHaveLength(1);
+      expect(secondPage.body).toHaveLength(1);
+      expect(firstPage.body[0].id).toBe(primaryLocation.id);
+      expect(firstPage.body[0].PhysicalAddresses).toHaveLength(2);
+      expect(secondPage.body[0].id).toBe(otherServiceLocation.id);
+      expect(secondPage.body[0].id).not.toBe(firstPage.body[0].id);
+    });
+
     it('should return the final page without a next-page header', () =>
       request(app)
         .get('/locations/catalog')

--- a/test/models/location-find-catalog.test.js
+++ b/test/models/location-find-catalog.test.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ */
+
+import models from '../../src/models';
+import geometry from '../../src/utils/geometry';
+
+describe('Location.findCatalog', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('paginates location ids before hydrating physical addresses', async () => {
+    jest.spyOn(models.Location, 'count').mockResolvedValue(2);
+    const findAllSpy = jest.spyOn(models.Location, 'findAll')
+      .mockResolvedValueOnce([
+        { id: 'location-1' },
+        { id: 'location-2' },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'location-2',
+          PhysicalAddresses: [{ id: 'addr-2' }],
+        },
+        {
+          id: 'location-1',
+          PhysicalAddresses: [{ id: 'addr-1a' }, { id: 'addr-1b' }],
+        },
+      ]);
+
+    const result = await models.Location.findCatalog({
+      position: geometry.createPoint(-73.981452, 40.763765),
+      radius: 20000,
+      limit: 2,
+      offset: 0,
+    });
+
+    const firstQuery = findAllSpy.mock.calls[0][0];
+    const secondQuery = findAllSpy.mock.calls[1][0];
+    const idFilterSymbols = Object.getOwnPropertySymbols(secondQuery.where.id);
+
+    expect(firstQuery).toEqual(expect.objectContaining({
+      attributes: ['id'],
+      limit: 2,
+      offset: 0,
+      raw: true,
+    }));
+    expect(firstQuery.include).toBeUndefined();
+    expect(secondQuery.limit).toBeUndefined();
+    expect(secondQuery.offset).toBeUndefined();
+    expect(secondQuery.include).toEqual(expect.any(Array));
+    expect(secondQuery.where.id[idFilterSymbols[0]]).toEqual(['location-1', 'location-2']);
+    expect(result.totalNumLocations).toBe(2);
+    expect(result.locations.map(location => location.id)).toEqual(['location-1', 'location-2']);
+    expect(result.locations[0].PhysicalAddresses).toHaveLength(2);
+  });
+});

--- a/test/services/internal-location-catalog-auth.test.js
+++ b/test/services/internal-location-catalog-auth.test.js
@@ -1,0 +1,205 @@
+const encodeBase64Url = value =>
+  Buffer.from(JSON.stringify(value))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+
+const buildJwt = (payload, header = { alg: 'RS256', kid: 'kid-1' }) => [
+  encodeBase64Url(header),
+  encodeBase64Url(payload),
+  'signature',
+].join('.');
+
+const ORIGINAL_ENV = process.env;
+
+const loadAuthorizeWithMocks = ({
+  allowedClientIds = 'allowed-client-id',
+  allowedHosts = 'sheets.doobneek.org',
+  allowedGroups,
+  verifyResult = true,
+} = {}) => {
+  jest.resetModules();
+  process.env = {
+    ...ORIGINAL_ENV,
+    NODE_ENV: 'test',
+    INTERNAL_LOCATION_CATALOG_ALLOWED_CLIENT_IDS: allowedClientIds,
+    INTERNAL_LOCATION_CATALOG_ALLOWED_HOSTS: allowedHosts,
+  };
+
+  if (allowedGroups === undefined) {
+    delete process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_GROUP_NAMES;
+  } else {
+    process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_GROUP_NAMES = allowedGroups;
+  }
+
+  const axios = require('axios');
+  const crypto = require('crypto');
+  const verify = {
+    update: jest.fn(),
+    end: jest.fn(),
+    verify: jest.fn(() => verifyResult),
+  };
+
+  jest.spyOn(axios, 'get').mockResolvedValue({
+    data: {
+      keys: [{ kid: 'kid-1', kty: 'RSA' }],
+    },
+  });
+  jest.spyOn(crypto, 'createPublicKey').mockReturnValue('mock-public-key');
+  jest.spyOn(crypto, 'createVerify').mockReturnValue(verify);
+
+  const authorizeInternalLocationCatalogRequest =
+    require('../../src/services/internal-location-catalog-auth').default;
+  const config = require('../../src/config').default;
+
+  return {
+    authorizeInternalLocationCatalogRequest,
+    config,
+    verify,
+    axios,
+  };
+};
+
+describe('internal location catalog auth', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('accepts a signed token from an allowed client without a browser origin', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+      verify,
+      axios,
+    } = loadAuthorizeWithMocks();
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'id',
+      aud: 'allowed-client-id',
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    })).resolves.toEqual(expect.objectContaining({
+      aud: 'allowed-client-id',
+      sub: 'user-123',
+    }));
+
+    expect(axios.get).toHaveBeenCalled();
+    expect(verify.verify).toHaveBeenCalled();
+  });
+
+  it('rejects a token from a disallowed client', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+    } = loadAuthorizeWithMocks();
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'id',
+      aud: 'some-other-client',
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    })).rejects.toThrow('Bearer token client is not allowed for internal location catalog');
+  });
+
+  it('rejects a browser origin that is not on the allowlist', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+    } = loadAuthorizeWithMocks();
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'id',
+      aud: 'allowed-client-id',
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+        origin: 'https://example.com',
+      },
+    })).rejects.toThrow('Origin not allowed for internal location catalog');
+  });
+
+  it('rejects a token with an invalid signature', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+    } = loadAuthorizeWithMocks({ verifyResult: false });
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'access',
+      client_id: 'allowed-client-id',
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    })).rejects.toThrow('Unable to verify bearer token');
+  });
+
+  it('rejects a token with an unsupported Cognito token type', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+    } = loadAuthorizeWithMocks();
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'refresh',
+      aud: 'allowed-client-id',
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    })).rejects.toThrow('Unsupported Cognito token type');
+  });
+
+  it('can require an allowed Cognito group in addition to the client id', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+    } = loadAuthorizeWithMocks({ allowedGroups: 'InternalCatalogUsers' });
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'id',
+      aud: 'allowed-client-id',
+      'cognito:groups': ['AnotherGroup'],
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    })).rejects.toThrow('Bearer token group is not allowed for internal location catalog');
+  });
+});

--- a/test/services/internal-location-catalog-auth.test.js
+++ b/test/services/internal-location-catalog-auth.test.js
@@ -15,9 +15,7 @@ const ORIGINAL_ENV = process.env;
 
 const loadAuthorizeWithMocks = ({
   allowedClientIds = 'allowed-client-id',
-  allowedHosts = 'sheets.doobneek.org',
-  allowedOriginPatterns = 'chrome-extension://*',
-  allowedGroups,
+  allowedGroups = 'InternalCatalogUsers',
   verifyResult = true,
 } = {}) => {
   jest.resetModules();
@@ -25,12 +23,15 @@ const loadAuthorizeWithMocks = ({
     ...ORIGINAL_ENV,
     NODE_ENV: 'test',
     COGNITO_USER_POOL_ID: 'us-east-1_testPool',
-    INTERNAL_LOCATION_CATALOG_ALLOWED_CLIENT_IDS: allowedClientIds,
-    INTERNAL_LOCATION_CATALOG_ALLOWED_HOSTS: allowedHosts,
-    INTERNAL_LOCATION_CATALOG_ALLOWED_ORIGIN_PATTERNS: allowedOriginPatterns,
   };
 
-  if (allowedGroups === undefined) {
+  if (allowedClientIds == null) {
+    delete process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_CLIENT_IDS;
+  } else {
+    process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_CLIENT_IDS = allowedClientIds;
+  }
+
+  if (allowedGroups == null) {
     delete process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_GROUP_NAMES;
   } else {
     process.env.INTERNAL_LOCATION_CATALOG_ALLOWED_GROUP_NAMES = allowedGroups;
@@ -70,7 +71,7 @@ describe('internal location catalog auth', () => {
     process.env = ORIGINAL_ENV;
   });
 
-  it('accepts a signed token from an allowed web origin and client', async () => {
+  it('accepts a signed token from an allowed client and group', async () => {
     const {
       authorizeInternalLocationCatalogRequest,
       config,
@@ -83,13 +84,13 @@ describe('internal location catalog auth', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
       token_use: 'id',
       aud: 'allowed-client-id',
+      'cognito:groups': ['InternalCatalogUsers'],
       sub: 'user-123',
     });
 
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
-        origin: 'https://sheets.doobneek.org',
       },
     })).resolves.toEqual(expect.objectContaining({
       aud: 'allowed-client-id',
@@ -111,18 +112,18 @@ describe('internal location catalog auth', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
       token_use: 'id',
       aud: 'some-other-client',
+      'cognito:groups': ['InternalCatalogUsers'],
       sub: 'user-123',
     });
 
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
-        origin: 'https://sheets.doobneek.org',
       },
     })).rejects.toThrow('Bearer token client is not allowed for internal location catalog');
   });
 
-  it('rejects authenticated requests that do not provide any origin context', async () => {
+  it('rejects a token from a disallowed group', async () => {
     const {
       authorizeInternalLocationCatalogRequest,
       config,
@@ -133,6 +134,7 @@ describe('internal location catalog auth', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
       token_use: 'id',
       aud: 'allowed-client-id',
+      'cognito:groups': ['AnotherGroup'],
       sub: 'user-123',
     });
 
@@ -140,29 +142,51 @@ describe('internal location catalog auth', () => {
       headers: {
         authorization: `Bearer ${token}`,
       },
-    })).rejects.toThrow('Origin not allowed for internal location catalog');
+    })).rejects.toThrow('Bearer token group is not allowed for internal location catalog');
   });
 
-  it('rejects a browser origin that is not on the allowlist', async () => {
+  it('fails closed when the allowed group configuration is missing', async () => {
     const {
       authorizeInternalLocationCatalogRequest,
       config,
-    } = loadAuthorizeWithMocks();
+    } = loadAuthorizeWithMocks({ allowedGroups: null });
 
     const token = buildJwt({
       iss: config.cognito.userPoolIssuer,
       exp: Math.floor(Date.now() / 1000) + 3600,
       token_use: 'id',
       aud: 'allowed-client-id',
+      'cognito:groups': ['InternalCatalogUsers'],
       sub: 'user-123',
     });
 
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
-        origin: 'https://example.com',
       },
-    })).rejects.toThrow('Origin not allowed for internal location catalog');
+    })).rejects.toThrow('Internal location catalog authorization is not configured');
+  });
+
+  it('fails closed when the allowed client configuration is missing', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+    } = loadAuthorizeWithMocks({ allowedClientIds: null });
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'id',
+      aud: 'allowed-client-id',
+      'cognito:groups': ['InternalCatalogUsers'],
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    })).rejects.toThrow('Internal location catalog authorization is not configured');
   });
 
   it('rejects a token with an invalid signature', async () => {
@@ -176,13 +200,13 @@ describe('internal location catalog auth', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
       token_use: 'access',
       client_id: 'allowed-client-id',
+      'cognito:groups': ['InternalCatalogUsers'],
       sub: 'user-123',
     });
 
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
-        origin: 'https://sheets.doobneek.org',
       },
     })).rejects.toThrow('Unable to verify bearer token');
   });
@@ -198,18 +222,18 @@ describe('internal location catalog auth', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
       token_use: 'refresh',
       aud: 'allowed-client-id',
+      'cognito:groups': ['InternalCatalogUsers'],
       sub: 'user-123',
     });
 
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
-        origin: 'https://sheets.doobneek.org',
       },
     })).rejects.toThrow('Unsupported Cognito token type');
   });
 
-  it('accepts an allowed extension origin pattern', async () => {
+  it('accepts an access token when both the client id and group are allowed', async () => {
     const {
       authorizeInternalLocationCatalogRequest,
       config,
@@ -220,40 +244,17 @@ describe('internal location catalog auth', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
       token_use: 'access',
       client_id: 'allowed-client-id',
+      'cognito:groups': ['InternalCatalogUsers'],
       sub: 'user-123',
     });
 
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
-        origin: 'chrome-extension://abcdefghijklmnop',
       },
     })).resolves.toEqual(expect.objectContaining({
       client_id: 'allowed-client-id',
     }));
-  });
-
-  it('can require an allowed Cognito group in addition to the client id', async () => {
-    const {
-      authorizeInternalLocationCatalogRequest,
-      config,
-    } = loadAuthorizeWithMocks({ allowedGroups: 'InternalCatalogUsers' });
-
-    const token = buildJwt({
-      iss: config.cognito.userPoolIssuer,
-      exp: Math.floor(Date.now() / 1000) + 3600,
-      token_use: 'id',
-      aud: 'allowed-client-id',
-      'cognito:groups': ['AnotherGroup'],
-      sub: 'user-123',
-    });
-
-    await expect(authorizeInternalLocationCatalogRequest({
-      headers: {
-        authorization: `Bearer ${token}`,
-        origin: 'https://sheets.doobneek.org',
-      },
-    })).rejects.toThrow('Bearer token group is not allowed for internal location catalog');
   });
 
   it('fails closed when the Cognito issuer is not configured', async () => {
@@ -287,13 +288,13 @@ describe('internal location catalog auth', () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
       token_use: 'id',
       aud: 'allowed-client-id',
+      'cognito:groups': ['InternalCatalogUsers'],
       sub: 'user-123',
     });
 
     await expect(reloadedAuthorize({
       headers: {
         authorization: `Bearer ${token}`,
-        origin: 'https://sheets.doobneek.org',
       },
     })).rejects.toThrow('Internal location catalog authorization is not configured');
 

--- a/test/services/internal-location-catalog-auth.test.js
+++ b/test/services/internal-location-catalog-auth.test.js
@@ -257,6 +257,38 @@ describe('internal location catalog auth', () => {
     }));
   });
 
+  it('re-verifies repeated requests instead of caching raw bearer tokens', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+      verify,
+      axios,
+    } = loadAuthorizeWithMocks();
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'id',
+      aud: 'allowed-client-id',
+      'cognito:groups': ['InternalCatalogUsers'],
+      sub: 'user-123',
+    });
+
+    await authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    await authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(verify.verify).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
   it('fails closed when the Cognito issuer is not configured', async () => {
     const {
       authorizeInternalLocationCatalogRequest,

--- a/test/services/internal-location-catalog-auth.test.js
+++ b/test/services/internal-location-catalog-auth.test.js
@@ -16,6 +16,7 @@ const ORIGINAL_ENV = process.env;
 const loadAuthorizeWithMocks = ({
   allowedClientIds = 'allowed-client-id',
   allowedHosts = 'sheets.doobneek.org',
+  allowedOriginPatterns = 'chrome-extension://*',
   allowedGroups,
   verifyResult = true,
 } = {}) => {
@@ -23,8 +24,10 @@ const loadAuthorizeWithMocks = ({
   process.env = {
     ...ORIGINAL_ENV,
     NODE_ENV: 'test',
+    COGNITO_USER_POOL_ID: 'us-east-1_testPool',
     INTERNAL_LOCATION_CATALOG_ALLOWED_CLIENT_IDS: allowedClientIds,
     INTERNAL_LOCATION_CATALOG_ALLOWED_HOSTS: allowedHosts,
+    INTERNAL_LOCATION_CATALOG_ALLOWED_ORIGIN_PATTERNS: allowedOriginPatterns,
   };
 
   if (allowedGroups === undefined) {
@@ -67,7 +70,7 @@ describe('internal location catalog auth', () => {
     process.env = ORIGINAL_ENV;
   });
 
-  it('accepts a signed token from an allowed client without a browser origin', async () => {
+  it('accepts a signed token from an allowed web origin and client', async () => {
     const {
       authorizeInternalLocationCatalogRequest,
       config,
@@ -86,6 +89,7 @@ describe('internal location catalog auth', () => {
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
+        origin: 'https://sheets.doobneek.org',
       },
     })).resolves.toEqual(expect.objectContaining({
       aud: 'allowed-client-id',
@@ -113,8 +117,30 @@ describe('internal location catalog auth', () => {
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
+        origin: 'https://sheets.doobneek.org',
       },
     })).rejects.toThrow('Bearer token client is not allowed for internal location catalog');
+  });
+
+  it('rejects authenticated requests that do not provide any origin context', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+    } = loadAuthorizeWithMocks();
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'id',
+      aud: 'allowed-client-id',
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    })).rejects.toThrow('Origin not allowed for internal location catalog');
   });
 
   it('rejects a browser origin that is not on the allowlist', async () => {
@@ -156,6 +182,7 @@ describe('internal location catalog auth', () => {
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
+        origin: 'https://sheets.doobneek.org',
       },
     })).rejects.toThrow('Unable to verify bearer token');
   });
@@ -177,8 +204,33 @@ describe('internal location catalog auth', () => {
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
+        origin: 'https://sheets.doobneek.org',
       },
     })).rejects.toThrow('Unsupported Cognito token type');
+  });
+
+  it('accepts an allowed extension origin pattern', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+      config,
+    } = loadAuthorizeWithMocks();
+
+    const token = buildJwt({
+      iss: config.cognito.userPoolIssuer,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'access',
+      client_id: 'allowed-client-id',
+      sub: 'user-123',
+    });
+
+    await expect(authorizeInternalLocationCatalogRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+        origin: 'chrome-extension://abcdefghijklmnop',
+      },
+    })).resolves.toEqual(expect.objectContaining({
+      client_id: 'allowed-client-id',
+    }));
   });
 
   it('can require an allowed Cognito group in addition to the client id', async () => {
@@ -199,7 +251,52 @@ describe('internal location catalog auth', () => {
     await expect(authorizeInternalLocationCatalogRequest({
       headers: {
         authorization: `Bearer ${token}`,
+        origin: 'https://sheets.doobneek.org',
       },
     })).rejects.toThrow('Bearer token group is not allowed for internal location catalog');
+  });
+
+  it('fails closed when the Cognito issuer is not configured', async () => {
+    const {
+      authorizeInternalLocationCatalogRequest,
+    } = loadAuthorizeWithMocks();
+    process.env = {
+      ...process.env,
+    };
+    delete process.env.COGNITO_USER_POOL_ID;
+    delete process.env.COGNITO_USER_POOL_ISSUER;
+    jest.resetModules();
+
+    const axios = require('axios');
+    const crypto = require('crypto');
+    jest.spyOn(axios, 'get').mockResolvedValue({
+      data: { keys: [{ kid: 'kid-1', kty: 'RSA' }] },
+    });
+    jest.spyOn(crypto, 'createPublicKey').mockReturnValue('mock-public-key');
+    jest.spyOn(crypto, 'createVerify').mockReturnValue({
+      update: jest.fn(),
+      end: jest.fn(),
+      verify: jest.fn(() => true),
+    });
+
+    const reloadedAuthorize =
+      require('../../src/services/internal-location-catalog-auth').default;
+
+    const token = buildJwt({
+      iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testPool',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      token_use: 'id',
+      aud: 'allowed-client-id',
+      sub: 'user-123',
+    });
+
+    await expect(reloadedAuthorize({
+      headers: {
+        authorization: `Bearer ${token}`,
+        origin: 'https://sheets.doobneek.org',
+      },
+    })).rejects.toThrow('Internal location catalog authorization is not configured');
+
+    expect(authorizeInternalLocationCatalogRequest).toBeDefined();
   });
 });

--- a/test/services/internal-location-catalog-cors.test.js
+++ b/test/services/internal-location-catalog-cors.test.js
@@ -1,0 +1,67 @@
+import express from 'express';
+import request from 'supertest';
+
+const ORIGINAL_ENV = process.env;
+
+const loadCorsMiddleware = ({
+  allowedHosts = 'sheets.doobneek.org',
+  allowedOriginPatterns = 'chrome-extension://*',
+} = {}) => {
+  jest.resetModules();
+  process.env = {
+    ...ORIGINAL_ENV,
+    INTERNAL_LOCATION_CATALOG_ALLOWED_HOSTS: allowedHosts,
+    INTERNAL_LOCATION_CATALOG_ALLOWED_ORIGIN_PATTERNS: allowedOriginPatterns,
+  };
+
+  const {
+    internalLocationCatalogCors,
+  } = require('../../src/services/internal-location-catalog-cors');
+
+  const app = express();
+  app.use('/locations/catalog', internalLocationCatalogCors);
+  app.options('/locations/catalog', (req, res) => res.sendStatus(204));
+  app.get('/locations/catalog', (req, res) => res.sendStatus(200));
+
+  return app;
+};
+
+describe('internal location catalog CORS', () => {
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('allows preflight requests from sheets.doobneek.org', async () => {
+    const app = loadCorsMiddleware();
+
+    await request(app)
+      .options('/locations/catalog')
+      .set('Origin', 'https://sheets.doobneek.org')
+      .set('Access-Control-Request-Method', 'GET')
+      .expect(204)
+      .expect('Access-Control-Allow-Origin', 'https://sheets.doobneek.org');
+  });
+
+  it('allows preflight requests from configured extension origins', async () => {
+    const app = loadCorsMiddleware();
+
+    await request(app)
+      .options('/locations/catalog')
+      .set('Origin', 'chrome-extension://abcdefghijklmnop')
+      .set('Access-Control-Request-Method', 'GET')
+      .expect(204)
+      .expect('Access-Control-Allow-Origin', 'chrome-extension://abcdefghijklmnop');
+  });
+
+  it('does not emit allow-origin headers for disallowed browser origins', async () => {
+    const app = loadCorsMiddleware();
+
+    const res = await request(app)
+      .options('/locations/catalog')
+      .set('Origin', 'https://example.com')
+      .set('Access-Control-Request-Method', 'GET')
+      .expect(204);
+
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});

--- a/test/services/internal-location-catalog-cors.test.js
+++ b/test/services/internal-location-catalog-cors.test.js
@@ -3,7 +3,7 @@ import request from 'supertest';
 
 const ORIGINAL_ENV = process.env;
 
-const loadCorsMiddleware = ({
+const buildCorsSelectorApp = ({
   allowedHosts = 'sheets.doobneek.org',
   allowedOriginPatterns = 'chrome-extension://*',
 } = {}) => {
@@ -15,13 +15,24 @@ const loadCorsMiddleware = ({
   };
 
   const {
+    publicApiCors,
     internalLocationCatalogCors,
   } = require('../../src/services/internal-location-catalog-cors');
 
   const app = express();
-  app.use('/locations/catalog', internalLocationCatalogCors);
+  app.use((req, res, next) => {
+    const useInternalCors = req.path === '/locations/catalog'
+      || req.path.startsWith('/locations/catalog/');
+    if (useInternalCors) {
+      return internalLocationCatalogCors(req, res, next);
+    }
+    return publicApiCors(req, res, next);
+  });
   app.options('/locations/catalog', (req, res) => res.sendStatus(204));
+  app.options('/locations/catalog/', (req, res) => res.sendStatus(204));
   app.get('/locations/catalog', (req, res) => res.sendStatus(200));
+  app.get('/locations/catalog/', (req, res) => res.sendStatus(200));
+  app.get('/locations/other', (req, res) => res.sendStatus(200));
 
   return app;
 };
@@ -32,7 +43,7 @@ describe('internal location catalog CORS', () => {
   });
 
   it('allows preflight requests from sheets.doobneek.org', async () => {
-    const app = loadCorsMiddleware();
+    const app = buildCorsSelectorApp();
 
     await request(app)
       .options('/locations/catalog')
@@ -43,7 +54,7 @@ describe('internal location catalog CORS', () => {
   });
 
   it('allows preflight requests from configured extension origins', async () => {
-    const app = loadCorsMiddleware();
+    const app = buildCorsSelectorApp();
 
     await request(app)
       .options('/locations/catalog')
@@ -54,7 +65,7 @@ describe('internal location catalog CORS', () => {
   });
 
   it('does not emit allow-origin headers for disallowed browser origins', async () => {
-    const app = loadCorsMiddleware();
+    const app = buildCorsSelectorApp();
 
     const res = await request(app)
       .options('/locations/catalog')
@@ -63,5 +74,27 @@ describe('internal location catalog CORS', () => {
       .expect(204);
 
     expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('keeps the restricted catalog CORS policy for trailing-slash variants', async () => {
+    const app = buildCorsSelectorApp();
+
+    const res = await request(app)
+      .options('/locations/catalog/')
+      .set('Origin', 'https://example.com')
+      .set('Access-Control-Request-Method', 'GET')
+      .expect(204);
+
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('still leaves unrelated routes on the public CORS policy', async () => {
+    const app = buildCorsSelectorApp();
+
+    await request(app)
+      .get('/locations/other')
+      .set('Origin', 'https://example.com')
+      .expect(200)
+      .expect('Access-Control-Allow-Origin', '*');
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,14 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
+if (!global.TextEncoder) {
+  global.TextEncoder = util.TextEncoder;
+}
+
+if (!global.TextDecoder) {
+  global.TextDecoder = util.TextDecoder;
+}
+
 jest.setTimeout(10000);
 
 process.env.DATABASE_NAME = 'test';


### PR DESCRIPTION
## Summary
- add a new authenticated /locations/catalog endpoint for internal catalog syncs without changing public /locations
- require explicit Cognito auth configuration for the internal catalog route, including configured app client IDs and optional group gating
- require an allowed browser or extension origin context instead of silently accepting missing/non-http origins
- fix API Gateway mock OPTIONS responses so authenticated browser clients can preflight the route
- add targeted unit coverage for auth-path and sortBy validation behavior

## Validation
- node --check src/services/internal-location-catalog-auth.js
- node --check src/controllers/validation/locations.js
- node --check test/services/internal-location-catalog-auth.test.js
- node --check test/controllers/locations-validation.test.js
- npx jest --runInBand test/services/internal-location-catalog-auth.test.js --config {setupFilesAfterEnv:[]}
- npx jest --runInBand test/controllers/locations-validation.test.js --config {setupFilesAfterEnv:[]}
- npm run build

## Notes
- the auth-path unit test avoids the repo's shared DB/app bootstrap and exercises the production verification logic directly
- I scanned the current branch diff plus the PR body/comments for token-like secrets and did not find any exposed bearer/API tokens, so no history rewrite was needed