### PR TITLE
Expose authenticated edit history API

### DIFF
--- a/sequelize/migrations/20260318101500-create-edit-history.js
+++ b/sequelize/migrations/20260318101500-create-edit-history.js
@@ -1,0 +1,100 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('edit_history', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4,
+        allowNull: false,
+      },
+      location_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+      },
+      service_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+      },
+      organization_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+      },
+      phone_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+      },
+      page_path: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      user_name: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      action: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      field: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      label: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      before_value: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      after_value: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      summary: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      resource_table: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      resource_id: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      source: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      action_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+      copyedit: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+    });
+
+    await queryInterface.addIndex('edit_history', ['location_id', 'action_at']);
+    await queryInterface.addIndex('edit_history', ['user_name', 'action_at']);
+    await queryInterface.addIndex('edit_history', ['page_path']);
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('edit_history');
+  },
+};

--- a/sequelize/migrations/20260318101500-create-edit-history.js
+++ b/sequelize/migrations/20260318101500-create-edit-history.js
@@ -27,6 +27,10 @@ module.exports = {
         type: Sequelize.TEXT,
         allowNull: false,
       },
+      user_key: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
       user_name: {
         type: Sequelize.TEXT,
         allowNull: false,
@@ -90,6 +94,7 @@ module.exports = {
     });
 
     await queryInterface.addIndex('edit_history', ['location_id', 'action_at']);
+    await queryInterface.addIndex('edit_history', ['user_key', 'action_at']);
     await queryInterface.addIndex('edit_history', ['user_name', 'action_at']);
     await queryInterface.addIndex('edit_history', ['page_path']);
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,11 @@
 import { parseBoolean, parseNumber } from './utils/strings';
 
+const databaseHost = process.env.DATABASE_HOST || 'localhost';
+const databaseSsl = parseBoolean(
+  process.env.DATABASE_SSL,
+  databaseHost !== 'localhost' && process.env.NODE_ENV !== 'test',
+);
+
 export default {
   port: process.env.PORT || 3000,
   slackWebhookUrl: process.env.SLACK_WEBHOOK_URL,
@@ -14,7 +20,7 @@ export default {
     ),
     logLargeQueries: parseBoolean(process.env.DATABASE_LOG_LARGE_QUERIES, true),
     options: {
-      host: process.env.DATABASE_HOST || 'localhost',
+      host: databaseHost,
       port: parseNumber(process.env.DATABASE_PORT, 5432),
       logging: parseBoolean(process.env.DATABASE_LOGGING, true),
       dialect: 'postgres',
@@ -30,10 +36,10 @@ export default {
       dialectOptions: {
         // Prevent `SET client_min_messages` so RDS Proxy can reuse pooled connections.
         clientMinMessages: process.env.DATABASE_CLIENT_MIN_MESSAGES || 'ignore',
-        ssl: {
+        ssl: databaseSsl ? {
           require: true,
           rejectUnauthorized: false, // For RDS, set to false to accept AWS certificates
-        },
+        } : false,
       },
     },
   },

--- a/src/controllers/comment-highlights.js
+++ b/src/controllers/comment-highlights.js
@@ -1,8 +1,19 @@
+/* eslint-disable no-console */
+
 import Joi from 'joi';
 import Sequelize from 'sequelize';
-import getCommentsHighlights from './openai';
 import models, { sequelize } from '../models';
 import commentSchemas from './validation/comments';
+
+let getCommentsHighlights = null;
+
+const loadCommentsHighlights = () => {
+  if (!getCommentsHighlights) {
+    // eslint-disable-next-line global-require
+    getCommentsHighlights = require('./openai').default;
+  }
+  return getCommentsHighlights;
+};
 
 async function doGenerateHighlights(results) {
   for (const location of results) {
@@ -18,7 +29,7 @@ async function doGenerateHighlights(results) {
       attributes: ['id', 'content'],
     });
 
-    const openAIOutput = await getCommentsHighlights(comments);
+    const openAIOutput = await loadCommentsHighlights()(comments);
 
     // get the latest comment for this location
     const [lastComment] = await sequelize.query(

--- a/src/controllers/comments.js
+++ b/src/controllers/comments.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, global-require */
+
 import Joi from 'joi';
 import { col, fn, cast, literal } from 'sequelize';
 import commentSchemas from './validation/comments';
@@ -8,21 +10,35 @@ import { regenerateHighlightsForLocation } from './comment-highlights';
 import commentEmail from '../services/comment-email';
 import { extractCommentContent } from '../utils/helpers';
 
-import {
-  CognitoIdentityProviderClient,
-  ListUsersCommand,
-} from '@aws-sdk/client-cognito-identity-provider';
+let cognitoClient = null;
+let ListUsersCommand = null;
 
-const client = new CognitoIdentityProviderClient({
-  region: 'us-east-1',
-});
+const loadCognitoClient = () => {
+  if (!cognitoClient || !ListUsersCommand) {
+    const {
+      CognitoIdentityProviderClient,
+      ListUsersCommand: LoadedListUsersCommand,
+    } = require('@aws-sdk/client-cognito-identity-provider');
+
+    ListUsersCommand = LoadedListUsersCommand;
+    cognitoClient = new CognitoIdentityProviderClient({
+      region: 'us-east-1',
+    });
+  }
+
+  return {
+    client: cognitoClient,
+    ListUsersCommand,
+  };
+};
 
 const getAllUsers = async (userPoolId) => {
+  const { client, ListUsersCommand: ListUsersCommandType } = loadCognitoClient();
   let users = [];
   let paginationToken;
 
   do {
-    const command = new ListUsersCommand({
+    const command = new ListUsersCommandType({
       UserPoolId: userPoolId,
       PaginationToken: paginationToken,
       Limit: 60, // Maximum allowed per request
@@ -299,7 +315,10 @@ export default {
         throw new NotFoundError('Comment not found');
       }
       //
-      if (!(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') && !req.userIsAdmin) {
+      if (
+        !(process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')
+        && !req.userIsAdmin
+      ) {
         throw new ForbiddenError('Not authorized to hide comments');
       }
 
@@ -316,7 +335,6 @@ export default {
           console.log(error);
         }
       });
-
     } catch (err) {
       next(err);
     }
@@ -413,4 +431,3 @@ export default {
     }
   },
 };
-

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -11,6 +11,7 @@ import {
   getCurrentUserEditHistory,
   getLocationEditHistory,
   getLocationEditTimeline,
+  recordHistorySafely,
   recordLocationCreateHistory,
   recordLocationUpdateHistory,
   recordPhoneCreateHistory,
@@ -26,8 +27,53 @@ import { NotFoundError, ValidationError } from '../utils/errors';
 
 const DEFAULT_MAX_LOCATIONS_RETURNED = 1000;
 const MAX_TAXONOMY_IDS = 200;
+const uniqueStrings = values => [...new Set(values.filter(Boolean).map(String))];
 const resolveHistoryActionAt = metadata =>
   (metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date());
+
+const loadLocationIdsForOrganization = async (organizationId) => {
+  if (!organizationId) return [];
+
+  const locations = await models.Location.findAll({
+    where: { organization_id: organizationId },
+    attributes: ['id'],
+    raw: true,
+    hooks: false,
+  });
+
+  return uniqueStrings(locations.map(({ id }) => id));
+};
+
+const loadLocationIdsForService = async (serviceId) => {
+  if (!serviceId) return [];
+
+  const serviceAtLocations = await models.ServiceAtLocation.findAll({
+    where: { service_id: serviceId },
+    attributes: ['location_id'],
+    raw: true,
+  });
+
+  return uniqueStrings(serviceAtLocations.map(({ location_id: locationId }) => locationId));
+};
+
+const loadLocationIdsForServiceAtLocation = async (serviceAtLocationId) => {
+  if (!serviceAtLocationId) return [];
+
+  const serviceAtLocation = await models.ServiceAtLocation.findByPk(serviceAtLocationId, {
+    attributes: ['location_id'],
+    raw: true,
+  });
+
+  return uniqueStrings([serviceAtLocation && serviceAtLocation.location_id]);
+};
+
+const resolvePhoneLocationIdsForDeletion = async phone =>
+  uniqueStrings([
+    phone.location_id,
+    ...(await loadLocationIdsForServiceAtLocation(phone.service_at_location_id)),
+    ...(await loadLocationIdsForService(phone.service_id)),
+    ...(await loadLocationIdsForOrganization(phone.organization_id)),
+  ]);
 
 const isLocationClosed = (occasion, eventRelatedInfos, services) => {
   if (!occasion) {
@@ -504,13 +550,13 @@ export default {
         postal_code: address.postalCode,
         country: address.country,
       }, { metadata });
-      await recordLocationCreateHistory({
+      await recordHistorySafely('recordLocationCreateHistory', () => recordLocationCreateHistory({
         location: createdLocation,
         input: req.body,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'location-api',
         actionAt: resolveHistoryActionAt(metadata),
-      });
+      }));
 
       res.status(201).send(createdLocation);
     } catch (err) {
@@ -603,13 +649,13 @@ export default {
       updatePromises.push(updateLocation(location, req.body, metadata));
 
       await Promise.all(updatePromises);
-      await recordLocationUpdateHistory({
+      await recordHistorySafely('recordLocationUpdateHistory', () => recordLocationUpdateHistory({
         locationBefore,
         input: req.body,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'location-api',
         actionAt: resolveHistoryActionAt(metadata),
-      });
+      }));
 
       res.sendStatus(204);
     } catch (err) {
@@ -644,14 +690,14 @@ export default {
         language,
         description,
       }, { metadata });
-      await recordPhoneCreateHistory({
+      await recordHistorySafely('recordPhoneCreateHistory', () => recordPhoneCreateHistory({
         locationId,
         phone: createdPhone,
         input: req.body,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'phone-api',
         actionAt: resolveHistoryActionAt(metadata),
-      });
+      }));
 
       res.status(201).send(createdPhone);
     } catch (err) {
@@ -674,13 +720,13 @@ export default {
       const { metadata, ...updateParams } = req.body;
       const phoneBefore = phone.get({ plain: true });
       await updateInstance(req.user, phone, updateParams, { fields: editableFields, metadata });
-      await recordPhoneUpdateHistory({
+      await recordHistorySafely('recordPhoneUpdateHistory', () => recordPhoneUpdateHistory({
         phoneBefore,
         input: updateParams,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'phone-api',
         actionAt: resolveHistoryActionAt(metadata),
-      });
+      }));
 
       res.sendStatus(204);
     } catch (err) {
@@ -700,13 +746,32 @@ export default {
       }
 
       const phoneBefore = phone.get({ plain: true });
-      await destroyInstance(req.user, phone);
-      await recordPhoneDeleteHistory({
+      const phoneLocationIds = await resolvePhoneLocationIdsForDeletion(phoneBefore);
+      const actionAt = new Date();
+
+      await models.sequelize.transaction(async (transaction) => {
+        await destroyInstance(req.user, phone, { transaction });
+
+        if (phoneLocationIds.length) {
+          await models.Metadata.bulkCreate(phoneLocationIds.map(locationId => ({
+            resource_table: models.Phone.tableName,
+            resource_id: phoneBefore.id,
+            last_action_date: actionAt,
+            last_action_type: models.Metadata.actionTypes.delete,
+            field_name: 'location_id',
+            previous_value: locationId,
+            updated_by: req.user,
+            source: 'phone-api',
+          })), { transaction });
+        }
+      });
+
+      await recordHistorySafely('recordPhoneDeleteHistory', () => recordPhoneDeleteHistory({
         phoneBefore,
         userName: req.userName || req.user,
         source: 'phone-api',
-        actionAt: new Date(),
-      });
+        actionAt,
+      }));
       res.sendStatus(204);
     } catch (err) {
       next(err);

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -23,13 +23,59 @@ import { eligibilityParams, documentTypes } from '../services/services';
 import geometry from '../utils/geometry';
 import { parseBoolean } from '../utils/strings';
 import { convertKeyValueArrayToObject } from '../utils/api-params';
-import { NotFoundError, ValidationError } from '../utils/errors';
+import { ForbiddenError, NotFoundError, ValidationError } from '../utils/errors';
 
 const DEFAULT_MAX_LOCATIONS_RETURNED = 1000;
 const MAX_TAXONOMY_IDS = 200;
 const uniqueStrings = values => [...new Set(values.filter(Boolean).map(String))];
 const resolveHistoryActionAt = metadata =>
   (metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date());
+const canReadAllAuditData = req =>
+  req.userIsAdmin || process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+const getUserOrganizationIds = req => uniqueStrings(req.userOrganizationIds || []);
+
+const loadAccessibleAuditLocationIds = async (req) => {
+  if (canReadAllAuditData(req)) {
+    return null;
+  }
+
+  const organizationIds = getUserOrganizationIds(req);
+  if (!organizationIds.length) {
+    return [];
+  }
+
+  const locations = await models.Location.findAll({
+    where: {
+      organization_id: {
+        [models.Sequelize.Op.in]: organizationIds,
+      },
+    },
+    attributes: ['id'],
+    raw: true,
+    hooks: false,
+  });
+
+  return uniqueStrings(locations.map(({ id }) => id));
+};
+
+const ensureLocationAuditAccess = async (req, locationId) => {
+  if (canReadAllAuditData(req)) {
+    return;
+  }
+
+  const location = await models.Location.findByPk(locationId, {
+    attributes: ['id', 'organization_id'],
+    raw: true,
+  });
+
+  if (!location) {
+    throw new NotFoundError('Location not found');
+  }
+
+  if (!getUserOrganizationIds(req).includes(location.organization_id)) {
+    throw new ForbiddenError('Not authorized to read edit history for this location');
+  }
+};
 
 const loadLocationIdsForOrganization = async (organizationId) => {
   if (!organizationId) return [];
@@ -355,7 +401,10 @@ export default {
     try {
       await Joi.validate(req, locationSchemas.getChanges, { allowUnknown: true });
 
-      const changes = await getLocationChanges(req.query);
+      const changes = await getLocationChanges({
+        ...req.query,
+        allowedLocationIds: await loadAccessibleAuditLocationIds(req),
+      });
       res.send(changes);
     } catch (err) {
       next(err);
@@ -365,6 +414,7 @@ export default {
   getEditHistory: async (req, res, next) => {
     try {
       await Joi.validate(req, locationSchemas.getEditHistory, { allowUnknown: true });
+      await ensureLocationAuditAccess(req, req.params.locationId);
 
       const history = await getLocationEditHistory({
         locationId: req.params.locationId,
@@ -380,9 +430,11 @@ export default {
   getEditTimeline: async (req, res, next) => {
     try {
       await Joi.validate(req, locationSchemas.getEditTimeline, { allowUnknown: true });
+      await ensureLocationAuditAccess(req, req.query.locationId);
 
       const timeline = await getLocationEditTimeline({
         locationId: req.query.locationId,
+        scope: req.query.scope || 'location',
         limit: req.query.limit,
         includeSegments: req.query.includeSegments,
       });
@@ -400,6 +452,7 @@ export default {
         userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         limit: req.query.limit,
+        allowedLocationIds: await loadAccessibleAuditLocationIds(req),
       });
       res.send(history);
     } catch (err) {

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -7,6 +7,16 @@ import {
   getMetadataForService,
   getLastValidatedDateForLocation,
 } from '../services/last-updates';
+import {
+  getCurrentUserEditHistory,
+  getLocationEditHistory,
+  getLocationEditTimeline,
+  recordLocationCreateHistory,
+  recordLocationUpdateHistory,
+  recordPhoneCreateHistory,
+  recordPhoneDeleteHistory,
+  recordPhoneUpdateHistory,
+} from '../services/edit-history';
 import { getLocationChanges } from '../services/location-changes';
 import { eligibilityParams, documentTypes } from '../services/services';
 import geometry from '../utils/geometry';
@@ -16,6 +26,8 @@ import { NotFoundError, ValidationError } from '../utils/errors';
 
 const DEFAULT_MAX_LOCATIONS_RETURNED = 1000;
 const MAX_TAXONOMY_IDS = 200;
+const resolveHistoryActionAt = metadata =>
+  (metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date());
 
 const isLocationClosed = (occasion, eventRelatedInfos, services) => {
   if (!occasion) {
@@ -304,6 +316,50 @@ export default {
     }
   },
 
+  getEditHistory: async (req, res, next) => {
+    try {
+      await Joi.validate(req, locationSchemas.getEditHistory, { allowUnknown: true });
+
+      const history = await getLocationEditHistory({
+        locationId: req.params.locationId,
+        limit: req.query.limit,
+        includeSegments: req.query.includeSegments,
+      });
+      res.send(history);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  getEditTimeline: async (req, res, next) => {
+    try {
+      await Joi.validate(req, locationSchemas.getEditTimeline, { allowUnknown: true });
+
+      const timeline = await getLocationEditTimeline({
+        locationId: req.query.locationId,
+        limit: req.query.limit,
+        includeSegments: req.query.includeSegments,
+      });
+      res.send(timeline);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  getCurrentUserEditHistory: async (req, res, next) => {
+    try {
+      await Joi.validate(req, locationSchemas.getCurrentUserEditHistory, { allowUnknown: true });
+
+      const history = await getCurrentUserEditHistory({
+        userName: req.userName || req.user,
+        limit: req.query.limit,
+      });
+      res.send(history);
+    } catch (err) {
+      next(err);
+    }
+  },
+
   getInfo: async (req, res, next) => {
     try {
       await Joi.validate(req, locationSchemas.getInfo, { allowUnknown: true });
@@ -448,6 +504,13 @@ export default {
         postal_code: address.postalCode,
         country: address.country,
       }, { metadata });
+      await recordLocationCreateHistory({
+        location: createdLocation,
+        input: req.body,
+        userName: req.userName || req.user,
+        source: metadata && metadata.source ? metadata.source : 'location-api',
+        actionAt: resolveHistoryActionAt(metadata),
+      });
 
       res.status(201).send(createdLocation);
     } catch (err) {
@@ -519,12 +582,13 @@ export default {
       const { metadata } = req.body;
 
       const location = await models.Location.findByPk(locationId, {
-        include: models.PhysicalAddress,
+        include: [models.PhysicalAddress, models.EventRelatedInfo],
       });
 
       if (!location) {
         throw new NotFoundError('Location not found');
       }
+      const locationBefore = location.get({ plain: true });
 
       const updatePromises = [];
 
@@ -539,6 +603,13 @@ export default {
       updatePromises.push(updateLocation(location, req.body, metadata));
 
       await Promise.all(updatePromises);
+      await recordLocationUpdateHistory({
+        locationBefore,
+        input: req.body,
+        userName: req.userName || req.user,
+        source: metadata && metadata.source ? metadata.source : 'location-api',
+        actionAt: resolveHistoryActionAt(metadata),
+      });
 
       res.sendStatus(204);
     } catch (err) {
@@ -573,6 +644,14 @@ export default {
         language,
         description,
       }, { metadata });
+      await recordPhoneCreateHistory({
+        locationId,
+        phone: createdPhone,
+        input: req.body,
+        userName: req.userName || req.user,
+        source: metadata && metadata.source ? metadata.source : 'phone-api',
+        actionAt: resolveHistoryActionAt(metadata),
+      });
 
       res.status(201).send(createdPhone);
     } catch (err) {
@@ -593,7 +672,15 @@ export default {
 
       const editableFields = ['number', 'extension', 'type', 'language', 'description'];
       const { metadata, ...updateParams } = req.body;
+      const phoneBefore = phone.get({ plain: true });
       await updateInstance(req.user, phone, updateParams, { fields: editableFields, metadata });
+      await recordPhoneUpdateHistory({
+        phoneBefore,
+        input: updateParams,
+        userName: req.userName || req.user,
+        source: metadata && metadata.source ? metadata.source : 'phone-api',
+        actionAt: resolveHistoryActionAt(metadata),
+      });
 
       res.sendStatus(204);
     } catch (err) {
@@ -612,7 +699,14 @@ export default {
         throw new NotFoundError('Phone not found');
       }
 
+      const phoneBefore = phone.get({ plain: true });
       await destroyInstance(req.user, phone);
+      await recordPhoneDeleteHistory({
+        phoneBefore,
+        userName: req.userName || req.user,
+        source: 'phone-api',
+        actionAt: new Date(),
+      });
       res.sendStatus(204);
     } catch (err) {
       next(err);

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -397,6 +397,7 @@ export default {
       await Joi.validate(req, locationSchemas.getCurrentUserEditHistory, { allowUnknown: true });
 
       const history = await getCurrentUserEditHistory({
+        userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         limit: req.query.limit,
       });
@@ -553,6 +554,7 @@ export default {
       await recordHistorySafely('recordLocationCreateHistory', () => recordLocationCreateHistory({
         location: createdLocation,
         input: req.body,
+        userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'location-api',
         actionAt: resolveHistoryActionAt(metadata),
@@ -652,6 +654,7 @@ export default {
       await recordHistorySafely('recordLocationUpdateHistory', () => recordLocationUpdateHistory({
         locationBefore,
         input: req.body,
+        userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'location-api',
         actionAt: resolveHistoryActionAt(metadata),
@@ -694,6 +697,7 @@ export default {
         locationId,
         phone: createdPhone,
         input: req.body,
+        userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'phone-api',
         actionAt: resolveHistoryActionAt(metadata),
@@ -723,6 +727,7 @@ export default {
       await recordHistorySafely('recordPhoneUpdateHistory', () => recordPhoneUpdateHistory({
         phoneBefore,
         input: updateParams,
+        userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'phone-api',
         actionAt: resolveHistoryActionAt(metadata),
@@ -768,6 +773,7 @@ export default {
 
       await recordHistorySafely('recordPhoneDeleteHistory', () => recordPhoneDeleteHistory({
         phoneBefore,
+        userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         source: 'phone-api',
         actionAt,

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -7,6 +7,7 @@ import {
   getMetadataForService,
   getLastValidatedDateForLocation,
 } from '../services/last-updates';
+import { getLocationChanges } from '../services/location-changes';
 import { eligibilityParams, documentTypes } from '../services/services';
 import geometry from '../utils/geometry';
 import { parseBoolean } from '../utils/strings';
@@ -287,6 +288,17 @@ export default {
         res.setHeader('Total-Count', totalNumLocations);
       }
       res.send(formattedLocations);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  getChanges: async (req, res, next) => {
+    try {
+      await Joi.validate(req, locationSchemas.getChanges, { allowUnknown: true });
+
+      const changes = await getLocationChanges(req.query);
+      res.send(changes);
     } catch (err) {
       next(err);
     }

--- a/src/controllers/organizations.js
+++ b/src/controllers/organizations.js
@@ -2,7 +2,10 @@ import Joi from 'joi';
 import organizationSchemas from './validation/organizations';
 import models from '../models';
 import { updateInstance, createInstance } from '../services/data-changes';
-import { recordOrganizationUpdateHistory } from '../services/edit-history';
+import {
+  recordHistorySafely,
+  recordOrganizationUpdateHistory,
+} from '../services/edit-history';
 import { NotFoundError } from '../utils/errors';
 
 export default {
@@ -64,13 +67,16 @@ export default {
         updateParams,
         { fields: editableFields, metadata },
       );
-      await recordOrganizationUpdateHistory({
-        organization: organizationBefore,
-        input: updateParams,
-        userName: req.userName || req.user,
-        source: metadata && metadata.source ? metadata.source : 'organization-api',
-        actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
-      });
+      await recordHistorySafely(
+        'recordOrganizationUpdateHistory',
+        () => recordOrganizationUpdateHistory({
+          organization: organizationBefore,
+          input: updateParams,
+          userName: req.userName || req.user,
+          source: metadata && metadata.source ? metadata.source : 'organization-api',
+          actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
+        }),
+      );
 
       res.sendStatus(204);
     } catch (err) {

--- a/src/controllers/organizations.js
+++ b/src/controllers/organizations.js
@@ -72,6 +72,7 @@ export default {
         () => recordOrganizationUpdateHistory({
           organization: organizationBefore,
           input: updateParams,
+          userKey: req.userSub || req.user,
           userName: req.userName || req.user,
           source: metadata && metadata.source ? metadata.source : 'organization-api',
           actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),

--- a/src/controllers/organizations.js
+++ b/src/controllers/organizations.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 import organizationSchemas from './validation/organizations';
 import models from '../models';
 import { updateInstance, createInstance } from '../services/data-changes';
+import { recordOrganizationUpdateHistory } from '../services/edit-history';
 import { NotFoundError } from '../utils/errors';
 
 export default {
@@ -56,12 +57,20 @@ export default {
 
       const editableFields = ['name', 'description', 'url'];
       const { metadata, ...updateParams } = req.body;
+      const organizationBefore = organization.get({ plain: true });
       await updateInstance(
         req.user,
         organization,
         updateParams,
         { fields: editableFields, metadata },
       );
+      await recordOrganizationUpdateHistory({
+        organization: organizationBefore,
+        input: updateParams,
+        userName: req.userName || req.user,
+        source: metadata && metadata.source ? metadata.source : 'organization-api',
+        actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
+      });
 
       res.sendStatus(204);
     } catch (err) {

--- a/src/controllers/services.js
+++ b/src/controllers/services.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 import serviceSchemas from './validation/services';
 import models, { sequelize } from '../models';
 import {
+  recordHistorySafely,
   recordServiceCreateHistory,
   recordServiceDeleteHistory,
   recordServiceUpdateHistory,
@@ -37,14 +38,14 @@ export default {
         req.user,
         metadata,
       );
-      await recordServiceCreateHistory({
+      await recordHistorySafely('recordServiceCreateHistory', () => recordServiceCreateHistory({
         locationId,
         service: createdService,
         input: otherProps,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'service-api',
         actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
-      });
+      }));
       res.status(201).send(createdService);
     } catch (err) {
       next(err);
@@ -101,13 +102,13 @@ export default {
       }
 
       await updateService(service, { ...otherProps, taxonomy }, req.user, metadata);
-      await recordServiceUpdateHistory({
+      await recordHistorySafely('recordServiceUpdateHistory', () => recordServiceUpdateHistory({
         serviceBefore,
         input: taxonomyId ? { ...otherProps, taxonomyId } : otherProps,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'service-api',
         actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
-      });
+      }));
       res.sendStatus(204);
     } catch (err) {
       next(err);
@@ -127,12 +128,12 @@ export default {
 
       await deleteService(serviceId, req.user);
       if (service) {
-        await recordServiceDeleteHistory({
+        await recordHistorySafely('recordServiceDeleteHistory', () => recordServiceDeleteHistory({
           serviceBefore: service.get({ plain: true }),
           userName: req.userName || req.user,
           source: 'service-api',
           actionAt: new Date(),
-        });
+        }));
       }
 
       res.sendStatus(204);

--- a/src/controllers/services.js
+++ b/src/controllers/services.js
@@ -42,6 +42,7 @@ export default {
         locationId,
         service: createdService,
         input: otherProps,
+        userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'service-api',
         actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
@@ -105,6 +106,7 @@ export default {
       await recordHistorySafely('recordServiceUpdateHistory', () => recordServiceUpdateHistory({
         serviceBefore,
         input: taxonomyId ? { ...otherProps, taxonomyId } : otherProps,
+        userKey: req.userSub || req.user,
         userName: req.userName || req.user,
         source: metadata && metadata.source ? metadata.source : 'service-api',
         actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
@@ -130,6 +132,7 @@ export default {
       if (service) {
         await recordHistorySafely('recordServiceDeleteHistory', () => recordServiceDeleteHistory({
           serviceBefore: service.get({ plain: true }),
+          userKey: req.userSub || req.user,
           userName: req.userName || req.user,
           source: 'service-api',
           actionAt: new Date(),

--- a/src/controllers/services.js
+++ b/src/controllers/services.js
@@ -1,6 +1,11 @@
 import Joi from 'joi';
 import serviceSchemas from './validation/services';
-import models, {sequelize} from '../models';
+import models, { sequelize } from '../models';
+import {
+  recordServiceCreateHistory,
+  recordServiceDeleteHistory,
+  recordServiceUpdateHistory,
+} from '../services/edit-history';
 import { createService, updateService, deleteService } from '../services/services';
 import { NotFoundError } from '../utils/errors';
 
@@ -32,6 +37,14 @@ export default {
         req.user,
         metadata,
       );
+      await recordServiceCreateHistory({
+        locationId,
+        service: createdService,
+        input: otherProps,
+        userName: req.userName || req.user,
+        source: metadata && metadata.source ? metadata.source : 'service-api',
+        actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
+      });
       res.status(201).send(createdService);
     } catch (err) {
       next(err);
@@ -46,7 +59,30 @@ export default {
       const { metadata, taxonomyId, ...otherProps } = req.body;
 
       const service = await models.Service.findByPk(serviceId, {
-        include: [models.DocumentsInfo],
+        include: [
+          models.DocumentsInfo,
+          models.RequiredDocument,
+          models.EventRelatedInfo,
+          models.HolidaySchedule,
+          models.RegularSchedule,
+          models.ServiceArea,
+          {
+            model: models.Eligibility,
+            include: [models.EligibilityParameter],
+          },
+          {
+            model: models.Language,
+            through: { attributes: [] },
+          },
+          {
+            model: models.Taxonomy,
+            through: { attributes: [] },
+          },
+          {
+            model: models.Location,
+            through: { attributes: [] },
+          },
+        ],
       });
       if (!service) {
         throw new NotFoundError('Service not found');
@@ -54,6 +90,7 @@ export default {
       if (!service.DocumentsInfo) {
         throw new Error('Service has no valid information about required documents');
       }
+      const serviceBefore = service.get({ plain: true });
 
       let taxonomy = null;
       if (taxonomyId) {
@@ -64,6 +101,13 @@ export default {
       }
 
       await updateService(service, { ...otherProps, taxonomy }, req.user, metadata);
+      await recordServiceUpdateHistory({
+        serviceBefore,
+        input: taxonomyId ? { ...otherProps, taxonomyId } : otherProps,
+        userName: req.userName || req.user,
+        source: metadata && metadata.source ? metadata.source : 'service-api',
+        actionAt: metadata && metadata.lastUpdated ? new Date(metadata.lastUpdated) : new Date(),
+      });
       res.sendStatus(204);
     } catch (err) {
       next(err);
@@ -74,8 +118,22 @@ export default {
     try {
       await Joi.validate(req, serviceSchemas.delete, { allowUnknown: true });
       const { serviceId } = req.params;
+      const service = await models.Service.findByPk(serviceId, {
+        include: [{
+          model: models.Location,
+          through: { attributes: [] },
+        }],
+      });
 
       await deleteService(serviceId, req.user);
+      if (service) {
+        await recordServiceDeleteHistory({
+          serviceBefore: service.get({ plain: true }),
+          userName: req.userName || req.user,
+          source: 'service-api',
+          actionAt: new Date(),
+        });
+      }
 
       res.sendStatus(204);
     } catch (err) {
@@ -85,8 +143,7 @@ export default {
 
   getCount: async (req, res, next) => {
     try {
-      const [servicesCount] = await sequelize.query(
-        `
+      const [servicesCount] = await sequelize.query(`
           select count(*)
           from locations
                  join organizations o on o.id = locations.organization_id
@@ -97,8 +154,7 @@ export default {
             from holiday_schedules as hs
                    join service_at_locations as sal on sal.service_id = hs.service_id
             where sal.location_id = locations.id
-          )    `,
-      );
+          )    `);
       res.send(servicesCount[0]).status(200);
     } catch (err) {
       next(err);

--- a/src/controllers/validation/locations.js
+++ b/src/controllers/validation/locations.js
@@ -60,6 +60,13 @@ export default {
     }).required(),
   },
 
+  getChanges: {
+    query: Joi.object().keys({
+      cursor: Joi.string(),
+      since: Joi.date().iso(),
+      limit: Joi.number().integer().positive().max(200),
+    }).required(),
+  },
   create: {
     body: Joi.object().keys({
       name: Joi.string(),

--- a/src/controllers/validation/locations.js
+++ b/src/controllers/validation/locations.js
@@ -81,7 +81,7 @@ export default {
   getEditTimeline: {
     query: Joi.object().keys({
       locationId: Joi.string().guid().required(),
-      scope: Joi.string().allow(''),
+      scope: Joi.string().valid('location', '').allow(''),
       limit: Joi.number().integer().positive().max(600),
       includeSegments: Joi.boolean(),
     }).required(),

--- a/src/controllers/validation/locations.js
+++ b/src/controllers/validation/locations.js
@@ -67,6 +67,32 @@ export default {
       limit: Joi.number().integer().positive().max(200),
     }).required(),
   },
+
+  getEditHistory: {
+    params: Joi.object().keys({
+      locationId: Joi.string().guid().required(),
+    }).required(),
+    query: Joi.object().keys({
+      limit: Joi.number().integer().positive().max(600),
+      includeSegments: Joi.boolean(),
+    }).required(),
+  },
+
+  getEditTimeline: {
+    query: Joi.object().keys({
+      locationId: Joi.string().guid().required(),
+      scope: Joi.string().allow(''),
+      limit: Joi.number().integer().positive().max(600),
+      includeSegments: Joi.boolean(),
+    }).required(),
+  },
+
+  getCurrentUserEditHistory: {
+    query: Joi.object().keys({
+      limit: Joi.number().integer().positive().max(600),
+    }).required(),
+  },
+
   create: {
     body: Joi.object().keys({
       name: Joi.string(),

--- a/src/middleware/get-user.js
+++ b/src/middleware/get-user.js
@@ -9,7 +9,13 @@ export default function getUser(req, res, next) {
     req.apiGateway.event.requestContext.authorizer.claims;
 
   if (claims && claims.sub) {
-    req.user = claims.sub;
+    req.userSub = claims.sub;
+    req.userName = claims['cognito:username'] ||
+      claims.preferred_username ||
+      claims.username ||
+      claims.email ||
+      claims.sub;
+    req.user = req.userName;
 
     const organizationClaims = claims['custom:orgs'];
     if (organizationClaims && organizationClaims.length) {
@@ -27,6 +33,8 @@ export default function getUser(req, res, next) {
 
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     req.user = '<Anonymous>';
+    req.userName = req.user;
+    req.userSub = req.user;
     next();
   } else {
     next(new AuthError());

--- a/src/middleware/get-user.js
+++ b/src/middleware/get-user.js
@@ -13,9 +13,8 @@ export default function getUser(req, res, next) {
     req.userName = claims['cognito:username'] ||
       claims.preferred_username ||
       claims.username ||
-      claims.email ||
       claims.sub;
-    req.user = req.userName;
+    req.user = claims.sub;
 
     const organizationClaims = claims['custom:orgs'];
     if (organizationClaims && organizationClaims.length) {

--- a/src/models/edit-history.js
+++ b/src/models/edit-history.js
@@ -1,0 +1,66 @@
+module.exports = (sequelize, DataTypes) => {
+  const EditHistory = sequelize.define('EditHistory', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    location_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
+    service_id: DataTypes.UUID,
+    organization_id: DataTypes.UUID,
+    phone_id: DataTypes.UUID,
+    page_path: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    user_name: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    action: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    field: DataTypes.TEXT,
+    label: DataTypes.TEXT,
+    before_value: DataTypes.TEXT,
+    after_value: DataTypes.TEXT,
+    summary: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    resource_table: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    resource_id: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    source: DataTypes.TEXT,
+    action_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    copyedit: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+  }, {
+    tableName: 'edit_history',
+    underscored: true,
+    underscoredAll: true,
+    indexes: [
+      { fields: ['location_id', 'action_at'] },
+      { fields: ['user_name', 'action_at'] },
+      { fields: ['page_path'] },
+    ],
+  });
+
+  return EditHistory;
+};

--- a/src/models/edit-history.js
+++ b/src/models/edit-history.js
@@ -16,6 +16,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.TEXT,
       allowNull: false,
     },
+    user_key: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
     user_name: {
       type: DataTypes.TEXT,
       allowNull: false,
@@ -57,6 +61,7 @@ module.exports = (sequelize, DataTypes) => {
     underscoredAll: true,
     indexes: [
       { fields: ['location_id', 'action_at'] },
+      { fields: ['user_key', 'action_at'] },
       { fields: ['user_name', 'action_at'] },
       { fields: ['page_path'] },
     ],

--- a/src/routes.js
+++ b/src/routes.js
@@ -23,7 +23,7 @@ export default (app) => {
   app.get('/organizations/:organizationId/locations', organizations.getLocations);
 
   app.get('/locations', locations.find);
-  app.get('/locations/changes', locations.getChanges);
+  app.get('/locations/changes', getUser, locations.getChanges);
   app.get('/locations/edit-history/user', getUser, locations.getCurrentUserEditHistory);
   app.get('/locations/edit-history/timeline', getUser, locations.getEditTimeline);
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -24,12 +24,15 @@ export default (app) => {
 
   app.get('/locations', locations.find);
   app.get('/locations/changes', locations.getChanges);
+  app.get('/locations/edit-history/user', getUser, locations.getCurrentUserEditHistory);
+  app.get('/locations/edit-history/timeline', getUser, locations.getEditTimeline);
 
   app.post('/locations/suggestions', locations.suggestNew);
   app.get('/locations-by-slug/:slug', locations.getInfoBySlug);
   app.get('/location-slug-redirects/:slug', locations.getRedirectBySlug);
 
   app.get('/locations/:locationId', locations.getInfo);
+  app.get('/locations/:locationId/edit-history', getUser, locations.getEditHistory);
   app.post('/locations', getUser, dataEntryAuth, locations.create);
   app.patch('/locations/:locationId', getUser, dataEntryAuth, locations.update);
 
@@ -64,7 +67,6 @@ export default (app) => {
   app.get('/comment-highlights', commentHighlights.getHighlights);
   app.post('/generate-highlights', commentHighlights.generateHighlights);
   app.post('/regenerate-highlights', commentHighlights.regenerateHighlights);
-
 
   app.get('/errorreports', getUser, errorReports.get);
   app.post('/errorreports', errorReports.create);

--- a/src/routes.js
+++ b/src/routes.js
@@ -23,6 +23,7 @@ export default (app) => {
   app.get('/organizations/:organizationId/locations', organizations.getLocations);
 
   app.get('/locations', locations.find);
+  app.get('/locations/changes', locations.getChanges);
 
   app.post('/locations/suggestions', locations.suggestNew);
   app.get('/locations-by-slug/:slug', locations.getInfoBySlug);

--- a/src/services/edit-history.js
+++ b/src/services/edit-history.js
@@ -10,6 +10,9 @@ const TIMELINE_PAGE_SUFFIXES = new Set(['description', 'other-info']);
 
 const UNKNOWN_HISTORY_USER = 'Unknown';
 const HISTORY_USER_DISPLAY_FALLBACK = 'User';
+const REDACTED_HISTORY_TEXT = '[redacted]';
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const PHONE_PATTERN = /(?:\+?1[\s.-]?)?(?:\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}\b/g;
 
 const normalizeHistoryUserKey = (value, fallback = UNKNOWN_HISTORY_USER) => {
   const normalized = String(value || '').trim();
@@ -68,6 +71,9 @@ const normalizeLimit = (value) => {
 };
 
 const uniqueStrings = values => [...new Set(values.filter(Boolean).map(value => String(value)))];
+const pagePathSuffix = pagePath => String(pagePath || '').split('/').pop().toLowerCase();
+const supportsTimelineTextPlayback = pagePath =>
+  TIMELINE_PAGE_SUFFIXES.has(pagePathSuffix(pagePath));
 
 const locationPagePath = locationId => `/team/location/${locationId}`;
 
@@ -84,6 +90,30 @@ const stringifyValue = (value) => {
   } catch (err) {
     return String(value);
   }
+};
+
+const sanitizeHistoryText = (value) => {
+  if (typeof value !== 'string') return value;
+  return value
+    .replace(EMAIL_PATTERN, REDACTED_HISTORY_TEXT)
+    .replace(PHONE_PATTERN, REDACTED_HISTORY_TEXT);
+};
+
+const sanitizeStoredValue = ({ pagePath, value }) => {
+  if (value == null) return null;
+
+  if (typeof value === 'string') {
+    if (!supportsTimelineTextPlayback(pagePath)) {
+      return null;
+    }
+    return sanitizeHistoryText(value);
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  return null;
 };
 
 const parseStoredValue = (value) => {
@@ -130,26 +160,6 @@ const humanizeField = (field) => {
     .replace(/\b\w/g, match => match.toUpperCase());
 };
 
-const previewValue = (value) => {
-  if (value == null) return '';
-  if (typeof value === 'string') return value.trim();
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-  if (Array.isArray(value)) {
-    return value.map(item => previewValue(item)).filter(Boolean).join(', ');
-  }
-  if (typeof value === 'object') {
-    const nestedPreview = [
-      value.name,
-      value.label,
-      value.title,
-      value.number,
-      value.information,
-    ].find(Boolean);
-    return previewValue(nestedPreview || '');
-  }
-  return '';
-};
-
 const areEqual = (left, right) => {
   if (left === right) return true;
   if (left == null || right == null) return false;
@@ -167,23 +177,21 @@ const buildSummary = ({
   action, label, before, after,
 }) => {
   const title = label || 'Edit';
-  const afterPreview = previewValue(after);
-  const beforePreview = previewValue(before);
 
   if (action === ACTION_CREATE) {
-    return afterPreview ? `Created ${title}: ${afterPreview}` : `Created ${title}`;
+    return `Created ${title}`;
   }
 
   if (action === ACTION_DELETE) {
-    return beforePreview ? `Deleted ${title}: ${beforePreview}` : `Deleted ${title}`;
+    return `Deleted ${title}`;
   }
 
   if (before == null && after != null) {
-    return afterPreview ? `Added ${title}: ${afterPreview}` : `Added ${title}`;
+    return `Added ${title}`;
   }
 
   if (after == null && before != null) {
-    return beforePreview ? `Removed ${title}: ${beforePreview}` : `Removed ${title}`;
+    return `Removed ${title}`;
   }
 
   return `Updated ${title}`;
@@ -240,6 +248,11 @@ const createEntry = ({
   actionAt = new Date(),
 }) => {
   const identity = buildHistoryUserIdentity({ userKey, userName });
+  const sanitizedBefore = sanitizeStoredValue({ pagePath, value: before });
+  const sanitizedAfter = sanitizeStoredValue({ pagePath, value: after });
+  const sanitizedSummary = sanitizeHistoryText(summary || buildSummary({
+    action, label, before, after,
+  }));
 
   return {
     location_id: locationId,
@@ -252,11 +265,9 @@ const createEntry = ({
     action,
     field,
     label: label || humanizeField(field),
-    before_value: stringifyValue(before),
-    after_value: stringifyValue(after),
-    summary: summary || buildSummary({
-      action, label, before, after,
-    }),
+    before_value: stringifyValue(sanitizedBefore),
+    after_value: stringifyValue(sanitizedAfter),
+    summary: sanitizedSummary,
     resource_table: resourceTable,
     resource_id: String(resourceId),
     source,
@@ -962,8 +973,6 @@ const mapEntryToEvent = (entry, { includeSegments = false } = {}) => {
     action: entry.action,
     field: entry.field || '',
     label: entry.label || humanizeField(entry.field),
-    before,
-    after,
     summary: entry.summary,
     note: entry.summary,
     ts: timestamp.toISOString(),
@@ -980,6 +989,14 @@ const mapEntryToEvent = (entry, { includeSegments = false } = {}) => {
     source: entry.source || null,
     copyedit: Boolean(entry.copyedit),
   };
+
+  if (before != null) {
+    event.before = before;
+  }
+
+  if (after != null) {
+    event.after = after;
+  }
 
   if (entry.page_path && /\/description$/i.test(entry.page_path)) {
     event.fieldKey = 'services.description';
@@ -1020,13 +1037,18 @@ export const getLocationEditHistory = async ({ locationId, limit, includeSegment
   };
 };
 
-export const getLocationEditTimeline = async ({ locationId, limit, includeSegments = false }) => {
+export const getLocationEditTimeline = async ({
+  locationId,
+  limit,
+  includeSegments = false,
+  scope = 'location',
+}) => {
   const normalizedLimit = normalizeLimit(limit);
   const entries = await loadLocationEntries({ locationId, limit: normalizedLimit });
   const events = entries
     .map(entry => mapEntryToEvent(entry, { includeSegments }))
     .filter((event) => {
-      const suffix = String(event.pagePath || '').split('/').pop();
+      const suffix = pagePathSuffix(event.pagePath);
       return TIMELINE_PAGE_SUFFIXES.has(suffix);
     })
     .sort((a, b) => a.timestampMs - b.timestampMs);
@@ -1048,16 +1070,61 @@ export const getLocationEditTimeline = async ({ locationId, limit, includeSegmen
   return {
     ok: true,
     locationId,
+    scope,
     generatedAt: new Date().toISOString(),
     pages,
   };
 };
 
-export const getCurrentUserEditHistory = async ({ userKey, userName, limit }) => {
+const normalizeAllowedLocationIds = (allowedLocationIds) => {
+  if (allowedLocationIds == null) {
+    return null;
+  }
+
+  if (allowedLocationIds instanceof Set) {
+    return uniqueStrings([...allowedLocationIds]);
+  }
+
+  if (Array.isArray(allowedLocationIds)) {
+    return uniqueStrings(allowedLocationIds);
+  }
+
+  return uniqueStrings([allowedLocationIds]);
+};
+
+export const getCurrentUserEditHistory = async ({
+  userKey,
+  userName,
+  limit,
+  allowedLocationIds = null,
+}) => {
   const normalizedLimit = normalizeLimit(limit);
   const identity = buildHistoryUserIdentity({ userKey, userName });
+  const allowedLocationIdList = normalizeAllowedLocationIds(allowedLocationIds);
+
+  if (allowedLocationIdList && !allowedLocationIdList.length) {
+    return {
+      user: {
+        key: identity.displayName,
+        name: identity.displayName,
+        normalized: identity.displayName,
+      },
+      data: {},
+    };
+  }
+
+  const where = {
+    user_key: identity.key,
+  };
+
+  if (allowedLocationIdList) {
+    where.location_id = {
+      [models.Sequelize.Op.in]: allowedLocationIdList,
+    };
+  }
+
   const entries = await models.EditHistory.findAll({
-    where: { user_key: identity.key },
+    where,
     order: [['action_at', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
     limit: normalizedLimit,
   });

--- a/src/services/edit-history.js
+++ b/src/services/edit-history.js
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import models from '../models';
 
 const DEFAULT_LIMIT = 200;
@@ -7,11 +8,55 @@ const ACTION_UPDATE = 'update';
 const ACTION_DELETE = 'delete';
 const TIMELINE_PAGE_SUFFIXES = new Set(['description', 'other-info']);
 
-const sanitizeHistoryUserName = (value, fallback = 'Unknown') => {
+const UNKNOWN_HISTORY_USER = 'Unknown';
+const HISTORY_USER_DISPLAY_FALLBACK = 'User';
+
+const normalizeHistoryUserKey = (value, fallback = UNKNOWN_HISTORY_USER) => {
   const normalized = String(value || '').trim();
-  if (!normalized) return fallback;
-  if (normalized.includes('@')) return fallback;
-  return normalized;
+  return normalized || fallback;
+};
+
+const isEmailLikeUserName = value =>
+  typeof value === 'string' && value.includes('@');
+
+const hashHistoryUserKey = (userKey) => {
+  const normalizedKey = normalizeHistoryUserKey(userKey, '');
+  if (!normalizedKey) return '';
+  return createHash('sha256').update(normalizedKey).digest('hex').slice(0, 10);
+};
+
+const buildHistoryDisplayName = ({
+  userKey,
+  userName,
+  fallback = HISTORY_USER_DISPLAY_FALLBACK,
+}) => {
+  const normalizedName = String(userName || '').trim();
+  if (normalizedName && !isEmailLikeUserName(normalizedName)) {
+    return normalizedName;
+  }
+
+  const normalizedKey = normalizeHistoryUserKey(userKey, '');
+  if (!normalizedKey || normalizedKey === UNKNOWN_HISTORY_USER) {
+    return fallback;
+  }
+
+  if (normalizedKey === '<Anonymous>') {
+    return normalizedKey;
+  }
+
+  return `${fallback} ${hashHistoryUserKey(normalizedKey)}`;
+};
+
+export const buildHistoryUserIdentity = ({ userKey, userName }) => {
+  const normalizedKey = normalizeHistoryUserKey(userKey || userName);
+
+  return {
+    key: normalizedKey,
+    displayName: buildHistoryDisplayName({
+      userKey: normalizedKey,
+      userName,
+    }),
+  };
 };
 
 const normalizeLimit = (value) => {
@@ -181,6 +226,7 @@ const createEntry = ({
   organizationId = null,
   phoneId = null,
   pagePath,
+  userKey,
   userName,
   action,
   field = '',
@@ -193,7 +239,7 @@ const createEntry = ({
   source = null,
   actionAt = new Date(),
 }) => {
-  const safeUserName = sanitizeHistoryUserName(userName);
+  const identity = buildHistoryUserIdentity({ userKey, userName });
 
   return {
     location_id: locationId,
@@ -201,7 +247,8 @@ const createEntry = ({
     organization_id: organizationId,
     phone_id: phoneId,
     page_path: pagePath,
-    user_name: safeUserName,
+    user_key: identity.key,
+    user_name: identity.displayName,
     action,
     field,
     label: label || humanizeField(field),
@@ -271,6 +318,7 @@ const buildLocationFieldEntries = ({
   resourceTable,
   resourceId,
   action,
+  userKey,
   userName,
   source,
   actionAt,
@@ -278,6 +326,7 @@ const buildLocationFieldEntries = ({
 }) => fields.map(field => createEntry({
   locationId,
   pagePath: locationPagePath(locationId),
+  userKey,
   userName,
   action,
   field: field.field,
@@ -295,6 +344,7 @@ const buildServiceEntries = ({
   locationIds,
   serviceId,
   action,
+  userKey,
   userName,
   source,
   actionAt,
@@ -309,6 +359,7 @@ const buildServiceEntries = ({
         locationId,
         serviceId,
         pagePath: servicePagePath(locationId, serviceId, field.pageSuffix || ''),
+        userKey,
         userName,
         action,
         field: field.field,
@@ -351,6 +402,7 @@ const filterMeaningfulRequiredDocuments = (documents = []) =>
 export const recordLocationCreateHistory = async ({
   location,
   input,
+  userKey,
   userName,
   source = 'location-api',
   actionAt = new Date(),
@@ -367,6 +419,7 @@ export const recordLocationCreateHistory = async ({
       locationId: location.id,
       organizationId: location.organization_id,
       pagePath: locationPagePath(location.id),
+      userKey,
       userName,
       action: ACTION_CREATE,
       field: 'location',
@@ -384,6 +437,7 @@ export const recordLocationCreateHistory = async ({
 export const recordLocationUpdateHistory = async ({
   locationBefore,
   input,
+  userKey,
   userName,
   source = 'location-api',
   actionAt = new Date(),
@@ -469,6 +523,7 @@ export const recordLocationUpdateHistory = async ({
     resourceTable: 'locations',
     resourceId: locationBefore.id,
     action: ACTION_UPDATE,
+    userKey,
     userName,
     source,
     actionAt,
@@ -480,6 +535,7 @@ export const recordPhoneCreateHistory = async ({
   locationId,
   phone,
   input,
+  userKey,
   userName,
   source = 'phone-api',
   actionAt = new Date(),
@@ -488,6 +544,7 @@ export const recordPhoneCreateHistory = async ({
     locationId,
     phoneId: phone.id,
     pagePath: locationPagePath(locationId),
+    userKey,
     userName,
     action: ACTION_CREATE,
     field: 'phone',
@@ -510,6 +567,7 @@ export const recordPhoneCreateHistory = async ({
 export const recordPhoneUpdateHistory = async ({
   phoneBefore,
   input,
+  userKey,
   userName,
   source = 'phone-api',
   actionAt = new Date(),
@@ -532,6 +590,7 @@ export const recordPhoneUpdateHistory = async ({
         locationId,
         phoneId: phoneBefore.id,
         pagePath: locationPagePath(locationId),
+        userKey,
         userName,
         action: ACTION_UPDATE,
         field: field.field,
@@ -551,6 +610,7 @@ export const recordPhoneUpdateHistory = async ({
 
 export const recordPhoneDeleteHistory = async ({
   phoneBefore,
+  userKey,
   userName,
   source = 'phone-api',
   actionAt = new Date(),
@@ -560,6 +620,7 @@ export const recordPhoneDeleteHistory = async ({
     locationId,
     phoneId: phoneBefore.id,
     pagePath: locationPagePath(locationId),
+    userKey,
     userName,
     action: ACTION_DELETE,
     field: 'phone',
@@ -584,6 +645,7 @@ export const recordPhoneDeleteHistory = async ({
 export const recordOrganizationUpdateHistory = async ({
   organization,
   input,
+  userKey,
   userName,
   source = 'organization-api',
   actionAt = new Date(),
@@ -606,6 +668,7 @@ export const recordOrganizationUpdateHistory = async ({
         locationId,
         organizationId: organization.id,
         pagePath: locationPagePath(locationId),
+        userKey,
         userName,
         action: ACTION_UPDATE,
         field: field.field,
@@ -627,6 +690,7 @@ export const recordServiceCreateHistory = async ({
   locationId,
   service,
   input,
+  userKey,
   userName,
   source = 'service-api',
   actionAt = new Date(),
@@ -637,6 +701,7 @@ export const recordServiceCreateHistory = async ({
       serviceId: service.id,
       organizationId: service.organization_id,
       pagePath: servicePagePath(locationId, service.id),
+      userKey,
       userName,
       action: ACTION_CREATE,
       field: 'service',
@@ -659,6 +724,7 @@ export const recordServiceCreateHistory = async ({
       serviceId: service.id,
       organizationId: service.organization_id,
       pagePath: servicePagePath(locationId, service.id, 'description'),
+      userKey,
       userName,
       action: ACTION_CREATE,
       field: 'description',
@@ -678,6 +744,7 @@ export const recordServiceCreateHistory = async ({
 export const recordServiceUpdateHistory = async ({
   serviceBefore,
   input,
+  userKey,
   userName,
   source = 'service-api',
   actionAt = new Date(),
@@ -836,6 +903,7 @@ export const recordServiceUpdateHistory = async ({
     locationIds,
     serviceId: serviceBefore.id,
     action: ACTION_UPDATE,
+    userKey,
     userName,
     source,
     actionAt,
@@ -847,6 +915,7 @@ export const recordServiceUpdateHistory = async ({
 
 export const recordServiceDeleteHistory = async ({
   serviceBefore,
+  userKey,
   userName,
   source = 'service-api',
   actionAt = new Date(),
@@ -863,6 +932,7 @@ export const recordServiceDeleteHistory = async ({
     locationIds,
     serviceId: serviceBefore.id,
     action: ACTION_DELETE,
+    userKey,
     userName,
     source,
     actionAt,
@@ -882,7 +952,10 @@ const mapEntryToEvent = (entry, { includeSegments = false } = {}) => {
   const before = parseStoredValue(entry.before_value);
   const after = parseStoredValue(entry.after_value);
   const timestamp = new Date(entry.action_at || entry.createdAt || new Date());
-  const safeUserName = sanitizeHistoryUserName(entry.user_name, 'User');
+  const displayUserName = buildHistoryDisplayName({
+    userKey: entry.user_key,
+    userName: entry.user_name,
+  });
   const event = {
     type: 'edit',
     kind: entry.action,
@@ -896,8 +969,8 @@ const mapEntryToEvent = (entry, { includeSegments = false } = {}) => {
     ts: timestamp.toISOString(),
     timestamp: timestamp.toISOString(),
     timestampMs: timestamp.getTime(),
-    userName: safeUserName,
-    user: safeUserName,
+    userName: displayUserName,
+    user: displayUserName,
     pagePath: entry.page_path,
     locationId: entry.location_id,
     serviceId: entry.service_id || '',
@@ -980,10 +1053,11 @@ export const getLocationEditTimeline = async ({ locationId, limit, includeSegmen
   };
 };
 
-export const getCurrentUserEditHistory = async ({ userName, limit }) => {
+export const getCurrentUserEditHistory = async ({ userKey, userName, limit }) => {
   const normalizedLimit = normalizeLimit(limit);
+  const identity = buildHistoryUserIdentity({ userKey, userName });
   const entries = await models.EditHistory.findAll({
-    where: { user_name: userName },
+    where: { user_key: identity.key },
     order: [['action_at', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
     limit: normalizedLimit,
   });
@@ -1005,9 +1079,9 @@ export const getCurrentUserEditHistory = async ({ userName, limit }) => {
 
   return {
     user: {
-      key: sanitizeHistoryUserName(userName),
-      name: sanitizeHistoryUserName(userName),
-      normalized: sanitizeHistoryUserName(userName),
+      key: identity.displayName,
+      name: identity.displayName,
+      normalized: identity.displayName,
     },
     data,
   };

--- a/src/services/edit-history.js
+++ b/src/services/edit-history.js
@@ -1,0 +1,1006 @@
+import models from '../models';
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 600;
+const ACTION_CREATE = 'create';
+const ACTION_UPDATE = 'update';
+const ACTION_DELETE = 'delete';
+const TIMELINE_PAGE_SUFFIXES = new Set(['description', 'other-info']);
+
+const normalizeLimit = (value) => {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(parsed, MAX_LIMIT);
+};
+
+const uniqueStrings = values => [...new Set(values.filter(Boolean).map(value => String(value)))];
+
+const locationPagePath = locationId => `/team/location/${locationId}`;
+
+const servicePagePath = (locationId, serviceId, suffix = '') => {
+  const basePath = `${locationPagePath(locationId)}/services/${serviceId}`;
+  return suffix ? `${basePath}/${suffix}` : basePath;
+};
+
+const stringifyValue = (value) => {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch (err) {
+    return String(value);
+  }
+};
+
+const parseStoredValue = (value) => {
+  if (value == null || value === '') return value;
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']')) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    try {
+      return JSON.parse(trimmed);
+    } catch (err) {
+      return value;
+    }
+  }
+  return value;
+};
+
+const humanizeField = (field) => {
+  const specialLabels = {
+    additional_info: 'Additional info',
+    address_1: 'Street',
+    postal_code: 'Postal code',
+    state_province: 'State',
+    organization_id: 'Organization',
+    who_does_it_serve: 'Who does it serve',
+    ages_served: 'Ages served',
+    event_related_info: 'Other info',
+    irregular_hours: 'Hours',
+  };
+
+  if (specialLabels[field]) {
+    return specialLabels[field];
+  }
+
+  return String(field || 'Edit')
+    .replace(/_/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, match => match.toUpperCase());
+};
+
+const previewValue = (value) => {
+  if (value == null) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return value.map(item => previewValue(item)).filter(Boolean).join(', ');
+  }
+  if (typeof value === 'object') {
+    const nestedPreview = [
+      value.name,
+      value.label,
+      value.title,
+      value.number,
+      value.information,
+    ].find(Boolean);
+    return previewValue(nestedPreview || '');
+  }
+  return '';
+};
+
+const areEqual = (left, right) => {
+  if (left === right) return true;
+  if (left == null || right == null) return false;
+  if (typeof left !== 'object' && typeof right !== 'object') {
+    return String(left) === String(right);
+  }
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch (err) {
+    return false;
+  }
+};
+
+const buildSummary = ({
+  action, label, before, after,
+}) => {
+  const title = label || 'Edit';
+  const afterPreview = previewValue(after);
+  const beforePreview = previewValue(before);
+
+  if (action === ACTION_CREATE) {
+    return afterPreview ? `Created ${title}: ${afterPreview}` : `Created ${title}`;
+  }
+
+  if (action === ACTION_DELETE) {
+    return beforePreview ? `Deleted ${title}: ${beforePreview}` : `Deleted ${title}`;
+  }
+
+  if (before == null && after != null) {
+    return afterPreview ? `Added ${title}: ${afterPreview}` : `Added ${title}`;
+  }
+
+  if (after == null && before != null) {
+    return beforePreview ? `Removed ${title}: ${beforePreview}` : `Removed ${title}`;
+  }
+
+  return `Updated ${title}`;
+};
+
+const buildSegments = (before, after) => {
+  if (typeof before !== 'string' || typeof after !== 'string') return null;
+
+  let prefix = 0;
+  while (prefix < before.length && prefix < after.length && before[prefix] === after[prefix]) {
+    prefix += 1;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < (before.length - prefix) &&
+    suffix < (after.length - prefix) &&
+    before[before.length - 1 - suffix] === after[after.length - 1 - suffix]
+  ) {
+    suffix += 1;
+  }
+
+  const segments = [];
+  const equalPrefix = after.slice(0, prefix);
+  const deletedText = before.slice(prefix, before.length - suffix);
+  const insertedText = after.slice(prefix, after.length - suffix);
+  const equalSuffix = suffix ? after.slice(after.length - suffix) : '';
+
+  if (equalPrefix) segments.push({ op: 'equal', text: equalPrefix });
+  if (deletedText) segments.push({ op: 'delete', text: deletedText });
+  if (insertedText) segments.push({ op: 'insert', text: insertedText });
+  if (equalSuffix) segments.push({ op: 'equal', text: equalSuffix });
+
+  return segments.length ? segments : null;
+};
+
+const createEntry = ({
+  locationId,
+  serviceId = null,
+  organizationId = null,
+  phoneId = null,
+  pagePath,
+  userName,
+  action,
+  field = '',
+  label = '',
+  before = null,
+  after = null,
+  summary = '',
+  resourceTable,
+  resourceId,
+  source = null,
+  actionAt = new Date(),
+}) => ({
+  location_id: locationId,
+  service_id: serviceId,
+  organization_id: organizationId,
+  phone_id: phoneId,
+  page_path: pagePath,
+  user_name: userName || 'Unknown',
+  action,
+  field,
+  label: label || humanizeField(field),
+  before_value: stringifyValue(before),
+  after_value: stringifyValue(after),
+  summary: summary || buildSummary({
+    action, label, before, after,
+  }),
+  resource_table: resourceTable,
+  resource_id: String(resourceId),
+  source,
+  action_at: actionAt,
+  copyedit: false,
+});
+
+const bulkCreateEntries = async (entries) => {
+  if (!entries.length) return [];
+  return models.EditHistory.bulkCreate(entries);
+};
+
+const loadLocationIdsForOrganization = async (organizationId) => {
+  const locations = await models.Location.findAll({
+    where: { organization_id: organizationId },
+    attributes: ['id'],
+    raw: true,
+  });
+  return uniqueStrings(locations.map(({ id }) => id));
+};
+
+const loadLocationIdsForService = async (serviceId) => {
+  const locations = await models.ServiceAtLocation.findAll({
+    where: { service_id: serviceId },
+    attributes: ['location_id'],
+    raw: true,
+  });
+  return uniqueStrings(locations.map(({ location_id: locationId }) => locationId));
+};
+
+const resolvePhoneLocationIds = async (phone) => {
+  if (phone.location_id) return [String(phone.location_id)];
+  if (phone.organization_id) return loadLocationIdsForOrganization(phone.organization_id);
+  if (phone.service_id) return loadLocationIdsForService(phone.service_id);
+  if (phone.service_at_location_id) {
+    const record = await models.ServiceAtLocation.findByPk(phone.service_at_location_id, {
+      attributes: ['location_id'],
+      raw: true,
+    });
+    return uniqueStrings([record && record.location_id]);
+  }
+  return [];
+};
+
+const buildLocationFieldEntries = ({
+  locationId,
+  resourceTable,
+  resourceId,
+  action,
+  userName,
+  source,
+  actionAt,
+  fields,
+}) => fields.map(field => createEntry({
+  locationId,
+  pagePath: locationPagePath(locationId),
+  userName,
+  action,
+  field: field.field,
+  label: field.label,
+  before: field.before,
+  after: field.after,
+  summary: field.summary,
+  resourceTable,
+  resourceId,
+  source,
+  actionAt,
+}));
+
+const buildServiceEntries = ({
+  locationIds,
+  serviceId,
+  action,
+  userName,
+  source,
+  actionAt,
+  resourceTable,
+  resourceId,
+  fields,
+}) => {
+  const entries = [];
+  locationIds.forEach((locationId) => {
+    fields.forEach((field) => {
+      entries.push(createEntry({
+        locationId,
+        serviceId,
+        pagePath: servicePagePath(locationId, serviceId, field.pageSuffix || ''),
+        userName,
+        action,
+        field: field.field,
+        label: field.label,
+        before: field.before,
+        after: field.after,
+        summary: field.summary,
+        resourceTable,
+        resourceId,
+        source,
+        actionAt,
+      }));
+    });
+  });
+  return entries;
+};
+
+const findServiceEventInfo = (serviceBefore, eventName) => {
+  const infos = serviceBefore && Array.isArray(serviceBefore.EventRelatedInfos)
+    ? serviceBefore.EventRelatedInfos
+    : [];
+  return infos.find(info => info.event === eventName) || null;
+};
+
+const findEligibilityValue = (serviceBefore) => {
+  const eligibilities = serviceBefore && Array.isArray(serviceBefore.Eligibilities)
+    ? serviceBefore.Eligibilities
+    : [];
+  const match = eligibilities.find(eligibility =>
+    eligibility.EligibilityParameter &&
+    eligibility.EligibilityParameter.name === 'age');
+  return match ? match.eligible_values : null;
+};
+
+const filterMeaningfulRequiredDocuments = (documents = []) =>
+  documents
+    .map(document => document && document.document)
+    .filter(document => document && String(document).trim().toLowerCase() !== 'none');
+
+export const recordLocationCreateHistory = async ({
+  location,
+  input,
+  userName,
+  source = 'location-api',
+  actionAt = new Date(),
+}) => {
+  const after = {
+    id: location.id,
+    name: input.name || location.name || null,
+    description: input.description || location.description || null,
+    additionalInfo: input.additionalInfo || location.additional_info || null,
+  };
+
+  return bulkCreateEntries([
+    createEntry({
+      locationId: location.id,
+      organizationId: location.organization_id,
+      pagePath: locationPagePath(location.id),
+      userName,
+      action: ACTION_CREATE,
+      field: 'location',
+      label: 'Location',
+      before: null,
+      after,
+      resourceTable: 'locations',
+      resourceId: location.id,
+      source,
+      actionAt,
+    }),
+  ]);
+};
+
+export const recordLocationUpdateHistory = async ({
+  locationBefore,
+  input,
+  userName,
+  source = 'location-api',
+  actionAt = new Date(),
+}) => {
+  const fields = [];
+  const address = Array.isArray(locationBefore.PhysicalAddresses)
+    ? locationBefore.PhysicalAddresses[0]
+    : null;
+
+  if (Object.prototype.hasOwnProperty.call(input, 'name')) {
+    fields.push({
+      field: 'name',
+      label: 'Name',
+      before: locationBefore.name,
+      after: input.name,
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'description')) {
+    fields.push({
+      field: 'description',
+      label: 'Description',
+      before: locationBefore.description,
+      after: input.description,
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'additionalInfo')) {
+    fields.push({
+      field: 'additional_info',
+      label: 'Additional info',
+      before: locationBefore.additional_info,
+      after: input.additionalInfo,
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'organizationId')) {
+    fields.push({
+      field: 'organization_id',
+      label: 'Organization',
+      before: locationBefore.organization_id,
+      after: input.organizationId,
+    });
+  }
+
+  if (input.address) {
+    [
+      ['street', 'address_1', 'Street'],
+      ['city', 'city', 'City'],
+      ['region', 'region', 'Region'],
+      ['state', 'state_province', 'State'],
+      ['postalCode', 'postal_code', 'Postal code'],
+      ['country', 'country', 'Country'],
+    ].forEach(([requestKey, currentKey, label]) => {
+      if (Object.prototype.hasOwnProperty.call(input.address, requestKey)) {
+        fields.push({
+          field: currentKey,
+          label,
+          before: address && address[currentKey],
+          after: input.address[requestKey],
+        });
+      }
+    });
+  }
+
+  if (input.eventRelatedInfo) {
+    const existingInfo = Array.isArray(locationBefore.EventRelatedInfos)
+      ? locationBefore.EventRelatedInfos.find(info => info.event === input.eventRelatedInfo.event)
+      : null;
+
+    fields.push({
+      field: 'event_related_info',
+      label: 'Other info',
+      before: existingInfo ? existingInfo.information : null,
+      after: input.eventRelatedInfo.information,
+    });
+  }
+
+  const changedFields = fields.filter(field => !areEqual(field.before, field.after));
+
+  return bulkCreateEntries(buildLocationFieldEntries({
+    locationId: locationBefore.id,
+    resourceTable: 'locations',
+    resourceId: locationBefore.id,
+    action: ACTION_UPDATE,
+    userName,
+    source,
+    actionAt,
+    fields: changedFields,
+  }));
+};
+
+export const recordPhoneCreateHistory = async ({
+  locationId,
+  phone,
+  input,
+  userName,
+  source = 'phone-api',
+  actionAt = new Date(),
+}) => bulkCreateEntries([
+  createEntry({
+    locationId,
+    phoneId: phone.id,
+    pagePath: locationPagePath(locationId),
+    userName,
+    action: ACTION_CREATE,
+    field: 'phone',
+    label: 'Phone',
+    before: null,
+    after: {
+      id: phone.id,
+      number: input.number,
+      extension: input.extension,
+      type: input.type,
+      description: input.description,
+    },
+    resourceTable: 'phones',
+    resourceId: phone.id,
+    source,
+    actionAt,
+  }),
+]);
+
+export const recordPhoneUpdateHistory = async ({
+  phoneBefore,
+  input,
+  userName,
+  source = 'phone-api',
+  actionAt = new Date(),
+}) => {
+  const locationIds = await resolvePhoneLocationIds(phoneBefore);
+  const fields = ['number', 'extension', 'type', 'language', 'description']
+    .filter(field => Object.prototype.hasOwnProperty.call(input, field))
+    .map(field => ({
+      field,
+      label: humanizeField(field),
+      before: phoneBefore[field],
+      after: input[field],
+    }))
+    .filter(field => !areEqual(field.before, field.after));
+
+  const entries = [];
+  locationIds.forEach((locationId) => {
+    fields.forEach((field) => {
+      entries.push(createEntry({
+        locationId,
+        phoneId: phoneBefore.id,
+        pagePath: locationPagePath(locationId),
+        userName,
+        action: ACTION_UPDATE,
+        field: field.field,
+        label: field.label,
+        before: field.before,
+        after: field.after,
+        resourceTable: 'phones',
+        resourceId: phoneBefore.id,
+        source,
+        actionAt,
+      }));
+    });
+  });
+
+  return bulkCreateEntries(entries);
+};
+
+export const recordPhoneDeleteHistory = async ({
+  phoneBefore,
+  userName,
+  source = 'phone-api',
+  actionAt = new Date(),
+}) => {
+  const locationIds = await resolvePhoneLocationIds(phoneBefore);
+  const entries = locationIds.map(locationId => createEntry({
+    locationId,
+    phoneId: phoneBefore.id,
+    pagePath: locationPagePath(locationId),
+    userName,
+    action: ACTION_DELETE,
+    field: 'phone',
+    label: 'Phone',
+    before: {
+      id: phoneBefore.id,
+      number: phoneBefore.number,
+      extension: phoneBefore.extension,
+      type: phoneBefore.type,
+      description: phoneBefore.description,
+    },
+    after: null,
+    resourceTable: 'phones',
+    resourceId: phoneBefore.id,
+    source,
+    actionAt,
+  }));
+
+  return bulkCreateEntries(entries);
+};
+
+export const recordOrganizationUpdateHistory = async ({
+  organization,
+  input,
+  userName,
+  source = 'organization-api',
+  actionAt = new Date(),
+}) => {
+  const locationIds = await loadLocationIdsForOrganization(organization.id);
+  const fieldDefs = ['name', 'description', 'url']
+    .filter(field => Object.prototype.hasOwnProperty.call(input, field))
+    .map(field => ({
+      field,
+      label: humanizeField(field),
+      before: organization[field],
+      after: input[field],
+    }))
+    .filter(field => !areEqual(field.before, field.after));
+
+  const entries = [];
+  locationIds.forEach((locationId) => {
+    fieldDefs.forEach((field) => {
+      entries.push(createEntry({
+        locationId,
+        organizationId: organization.id,
+        pagePath: locationPagePath(locationId),
+        userName,
+        action: ACTION_UPDATE,
+        field: field.field,
+        label: field.label,
+        before: field.before,
+        after: field.after,
+        resourceTable: 'organizations',
+        resourceId: organization.id,
+        source,
+        actionAt,
+      }));
+    });
+  });
+
+  return bulkCreateEntries(entries);
+};
+
+export const recordServiceCreateHistory = async ({
+  locationId,
+  service,
+  input,
+  userName,
+  source = 'service-api',
+  actionAt = new Date(),
+}) => {
+  const entries = [
+    createEntry({
+      locationId,
+      serviceId: service.id,
+      organizationId: service.organization_id,
+      pagePath: servicePagePath(locationId, service.id),
+      userName,
+      action: ACTION_CREATE,
+      field: 'service',
+      label: 'Service',
+      before: null,
+      after: {
+        id: service.id,
+        name: input.name || service.name || null,
+      },
+      resourceTable: 'services',
+      resourceId: service.id,
+      source,
+      actionAt,
+    }),
+  ];
+
+  if (input.description != null) {
+    entries.push(createEntry({
+      locationId,
+      serviceId: service.id,
+      organizationId: service.organization_id,
+      pagePath: servicePagePath(locationId, service.id, 'description'),
+      userName,
+      action: ACTION_CREATE,
+      field: 'description',
+      label: 'Description',
+      before: '',
+      after: input.description,
+      resourceTable: 'services',
+      resourceId: service.id,
+      source,
+      actionAt,
+    }));
+  }
+
+  return bulkCreateEntries(entries);
+};
+
+export const recordServiceUpdateHistory = async ({
+  serviceBefore,
+  input,
+  userName,
+  source = 'service-api',
+  actionAt = new Date(),
+}) => {
+  const locationIds = uniqueStrings((serviceBefore.Locations || []).map(location => location.id));
+  if (!locationIds.length) return [];
+
+  const fields = [];
+
+  if (Object.prototype.hasOwnProperty.call(input, 'name')) {
+    fields.push({
+      field: 'name',
+      label: 'Name',
+      before: serviceBefore.name,
+      after: input.name,
+      pageSuffix: '',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'description')) {
+    fields.push({
+      field: 'description',
+      label: 'Description',
+      before: serviceBefore.description,
+      after: input.description,
+      pageSuffix: 'description',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'url')) {
+    fields.push({
+      field: 'url',
+      label: 'URL',
+      before: serviceBefore.url,
+      after: input.url,
+      pageSuffix: '',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'additionalInfo')) {
+    fields.push({
+      field: 'additional_info',
+      label: 'Additional info',
+      before: serviceBefore.additional_info,
+      after: input.additionalInfo,
+      pageSuffix: '',
+    });
+  }
+
+  if (input.eventRelatedInfo) {
+    const existingInfo = findServiceEventInfo(serviceBefore, input.eventRelatedInfo.event);
+    fields.push({
+      field: 'additional_info',
+      label: 'Other info',
+      before: existingInfo ? existingInfo.information : null,
+      after: input.eventRelatedInfo.information,
+      pageSuffix: 'other-info',
+    });
+  }
+
+  if (input.documents && Object.prototype.hasOwnProperty.call(input.documents, 'proofs')) {
+    fields.push({
+      field: 'required_documents',
+      label: 'Required documents',
+      before: filterMeaningfulRequiredDocuments(serviceBefore.RequiredDocuments || []),
+      after: input.documents.proofs,
+      pageSuffix: 'documents/proofs-required',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'whoDoesItServe')) {
+    fields.push({
+      field: 'who_does_it_serve',
+      label: 'Who does it serve',
+      before: serviceBefore.who_does_it_serve || findEligibilityValue(serviceBefore),
+      after: input.whoDoesItServe,
+      pageSuffix: 'who-does-it-serve',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'irregularHours')) {
+    fields.push({
+      field: 'irregular_hours',
+      label: 'Hours',
+      before: serviceBefore.HolidaySchedules || [],
+      after: input.irregularHours,
+      pageSuffix: 'opening-hours',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'hours')) {
+    fields.push({
+      field: 'hours',
+      label: 'Hours',
+      before: serviceBefore.RegularSchedules || [],
+      after: input.hours,
+      pageSuffix: 'opening-hours',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'languageIds')) {
+    fields.push({
+      field: 'language_ids',
+      label: 'Languages',
+      before: (serviceBefore.Languages || []).map(language => language.id),
+      after: input.languageIds,
+      pageSuffix: '',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'taxonomyId')) {
+    fields.push({
+      field: 'taxonomy_id',
+      label: 'Taxonomy',
+      before: (serviceBefore.Taxonomies || []).map(taxonomy => taxonomy.id),
+      after: input.taxonomyId,
+      pageSuffix: '',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'agesServed')) {
+    fields.push({
+      field: 'ages_served',
+      label: 'Ages served',
+      before: serviceBefore.ages_served,
+      after: input.agesServed,
+      pageSuffix: '',
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'area')) {
+    fields.push({
+      field: 'service_area',
+      label: 'Service area',
+      before: (serviceBefore.ServiceAreas || []).map(area => area.postal_codes),
+      after: input.area,
+      pageSuffix: '',
+    });
+  }
+
+  if (!fields.length) {
+    fields.push({
+      field: 'service',
+      label: 'Service',
+      before: null,
+      after: input,
+      pageSuffix: '',
+      summary: 'Updated service',
+    });
+  }
+
+  const changedFields = fields.filter(field =>
+    field.summary === 'Updated service' || !areEqual(field.before, field.after));
+
+  return bulkCreateEntries(buildServiceEntries({
+    locationIds,
+    serviceId: serviceBefore.id,
+    action: ACTION_UPDATE,
+    userName,
+    source,
+    actionAt,
+    resourceTable: 'services',
+    resourceId: serviceBefore.id,
+    fields: changedFields,
+  }));
+};
+
+export const recordServiceDeleteHistory = async ({
+  serviceBefore,
+  userName,
+  source = 'service-api',
+  actionAt = new Date(),
+}) => {
+  const locationIds = uniqueStrings((serviceBefore.Locations || []).map(location => location.id));
+  if (!locationIds.length) return [];
+
+  const before = {
+    id: serviceBefore.id,
+    name: serviceBefore.name,
+  };
+
+  return bulkCreateEntries(buildServiceEntries({
+    locationIds,
+    serviceId: serviceBefore.id,
+    action: ACTION_DELETE,
+    userName,
+    source,
+    actionAt,
+    resourceTable: 'services',
+    resourceId: serviceBefore.id,
+    fields: [{
+      field: 'service',
+      label: 'Service',
+      before,
+      after: null,
+      pageSuffix: '',
+    }],
+  }));
+};
+
+const mapEntryToEvent = (entry, { includeSegments = false } = {}) => {
+  const before = parseStoredValue(entry.before_value);
+  const after = parseStoredValue(entry.after_value);
+  const timestamp = new Date(entry.action_at || entry.createdAt || new Date());
+  const event = {
+    type: 'edit',
+    kind: entry.action,
+    action: entry.action,
+    field: entry.field || '',
+    label: entry.label || humanizeField(entry.field),
+    before,
+    after,
+    summary: entry.summary,
+    note: entry.summary,
+    ts: timestamp.toISOString(),
+    timestamp: timestamp.toISOString(),
+    timestampMs: timestamp.getTime(),
+    userName: entry.user_name,
+    user: entry.user_name,
+    pagePath: entry.page_path,
+    locationId: entry.location_id,
+    serviceId: entry.service_id || '',
+    phoneId: entry.phone_id || '',
+    resourceTable: entry.resource_table,
+    resourceId: entry.resource_id,
+    source: entry.source || null,
+    copyedit: Boolean(entry.copyedit),
+  };
+
+  if (entry.page_path && /\/description$/i.test(entry.page_path)) {
+    event.fieldKey = 'services.description';
+  } else if (entry.page_path && /\/other-info$/i.test(entry.page_path)) {
+    event.fieldKey = 'services.additional_info';
+  }
+
+  if (
+    includeSegments &&
+    typeof before === 'string' &&
+    typeof after === 'string' &&
+    before !== after
+  ) {
+    const segments = buildSegments(before, after);
+    if (segments) event.segments = segments;
+  }
+
+  return event;
+};
+
+const loadLocationEntries = async ({ locationId, limit }) => models.EditHistory.findAll({
+  where: { location_id: locationId },
+  order: [['action_at', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
+  limit,
+});
+
+export const getLocationEditHistory = async ({ locationId, limit, includeSegments = false }) => {
+  const normalizedLimit = normalizeLimit(limit);
+  const entries = await loadLocationEntries({ locationId, limit: normalizedLimit });
+  const edits = entries.map(entry => mapEntryToEvent(entry, { includeSegments }));
+
+  return {
+    ok: true,
+    locationId,
+    edits,
+    count: edits.length,
+    generatedAt: new Date().toISOString(),
+  };
+};
+
+export const getLocationEditTimeline = async ({ locationId, limit, includeSegments = false }) => {
+  const normalizedLimit = normalizeLimit(limit);
+  const entries = await loadLocationEntries({ locationId, limit: normalizedLimit });
+  const events = entries
+    .map(entry => mapEntryToEvent(entry, { includeSegments }))
+    .filter((event) => {
+      const suffix = String(event.pagePath || '').split('/').pop();
+      return TIMELINE_PAGE_SUFFIXES.has(suffix);
+    })
+    .sort((a, b) => a.timestampMs - b.timestampMs);
+
+  const pages = {};
+  events.forEach((event) => {
+    const key = encodeURIComponent(event.pagePath);
+    if (!pages[key]) {
+      pages[key] = {
+        pagePath: event.pagePath,
+        fieldKey: event.fieldKey || '',
+        label: event.label || '',
+        events: [],
+      };
+    }
+    pages[key].events.push(event);
+  });
+
+  return {
+    ok: true,
+    locationId,
+    generatedAt: new Date().toISOString(),
+    pages,
+  };
+};
+
+export const getCurrentUserEditHistory = async ({ userName, limit }) => {
+  const normalizedLimit = normalizeLimit(limit);
+  const entries = await models.EditHistory.findAll({
+    where: { user_name: userName },
+    order: [['action_at', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
+    limit: normalizedLimit,
+  });
+
+  const data = {};
+  entries.forEach((entry) => {
+    const event = mapEntryToEvent(entry);
+    if (!data[event.pagePath]) {
+      data[event.pagePath] = {};
+    }
+
+    let timestamp = event.timestampMs;
+    while (Object.prototype.hasOwnProperty.call(data[event.pagePath], String(timestamp))) {
+      timestamp += 1;
+    }
+
+    data[event.pagePath][String(timestamp)] = event;
+  });
+
+  return {
+    user: {
+      key: userName,
+      name: userName,
+      normalized: userName,
+    },
+    data,
+  };
+};
+
+export default {
+  getCurrentUserEditHistory,
+  getLocationEditHistory,
+  getLocationEditTimeline,
+  recordLocationCreateHistory,
+  recordLocationUpdateHistory,
+  recordOrganizationUpdateHistory,
+  recordPhoneCreateHistory,
+  recordPhoneDeleteHistory,
+  recordPhoneUpdateHistory,
+  recordServiceCreateHistory,
+  recordServiceDeleteHistory,
+  recordServiceUpdateHistory,
+};

--- a/src/services/edit-history.js
+++ b/src/services/edit-history.js
@@ -7,6 +7,13 @@ const ACTION_UPDATE = 'update';
 const ACTION_DELETE = 'delete';
 const TIMELINE_PAGE_SUFFIXES = new Set(['description', 'other-info']);
 
+const sanitizeHistoryUserName = (value, fallback = 'Unknown') => {
+  const normalized = String(value || '').trim();
+  if (!normalized) return fallback;
+  if (normalized.includes('@')) return fallback;
+  return normalized;
+};
+
 const normalizeLimit = (value) => {
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -185,31 +192,45 @@ const createEntry = ({
   resourceId,
   source = null,
   actionAt = new Date(),
-}) => ({
-  location_id: locationId,
-  service_id: serviceId,
-  organization_id: organizationId,
-  phone_id: phoneId,
-  page_path: pagePath,
-  user_name: userName || 'Unknown',
-  action,
-  field,
-  label: label || humanizeField(field),
-  before_value: stringifyValue(before),
-  after_value: stringifyValue(after),
-  summary: summary || buildSummary({
-    action, label, before, after,
-  }),
-  resource_table: resourceTable,
-  resource_id: String(resourceId),
-  source,
-  action_at: actionAt,
-  copyedit: false,
-});
+}) => {
+  const safeUserName = sanitizeHistoryUserName(userName);
+
+  return {
+    location_id: locationId,
+    service_id: serviceId,
+    organization_id: organizationId,
+    phone_id: phoneId,
+    page_path: pagePath,
+    user_name: safeUserName,
+    action,
+    field,
+    label: label || humanizeField(field),
+    before_value: stringifyValue(before),
+    after_value: stringifyValue(after),
+    summary: summary || buildSummary({
+      action, label, before, after,
+    }),
+    resource_table: resourceTable,
+    resource_id: String(resourceId),
+    source,
+    action_at: actionAt,
+    copyedit: false,
+  };
+};
 
 const bulkCreateEntries = async (entries) => {
   if (!entries.length) return [];
   return models.EditHistory.bulkCreate(entries);
+};
+
+export const recordHistorySafely = async (label, writer) => {
+  try {
+    return await writer();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(`[edit-history] ${label} failed`, err);
+    return null;
+  }
 };
 
 const loadLocationIdsForOrganization = async (organizationId) => {
@@ -217,6 +238,7 @@ const loadLocationIdsForOrganization = async (organizationId) => {
     where: { organization_id: organizationId },
     attributes: ['id'],
     raw: true,
+    hooks: false,
   });
   return uniqueStrings(locations.map(({ id }) => id));
 };
@@ -860,6 +882,7 @@ const mapEntryToEvent = (entry, { includeSegments = false } = {}) => {
   const before = parseStoredValue(entry.before_value);
   const after = parseStoredValue(entry.after_value);
   const timestamp = new Date(entry.action_at || entry.createdAt || new Date());
+  const safeUserName = sanitizeHistoryUserName(entry.user_name, 'User');
   const event = {
     type: 'edit',
     kind: entry.action,
@@ -873,8 +896,8 @@ const mapEntryToEvent = (entry, { includeSegments = false } = {}) => {
     ts: timestamp.toISOString(),
     timestamp: timestamp.toISOString(),
     timestampMs: timestamp.getTime(),
-    userName: entry.user_name,
-    user: entry.user_name,
+    userName: safeUserName,
+    user: safeUserName,
     pagePath: entry.page_path,
     locationId: entry.location_id,
     serviceId: entry.service_id || '',
@@ -982,9 +1005,9 @@ export const getCurrentUserEditHistory = async ({ userName, limit }) => {
 
   return {
     user: {
-      key: userName,
-      name: userName,
-      normalized: userName,
+      key: sanitizeHistoryUserName(userName),
+      name: sanitizeHistoryUserName(userName),
+      normalized: sanitizeHistoryUserName(userName),
     },
     data,
   };

--- a/src/services/location-changes.js
+++ b/src/services/location-changes.js
@@ -1,0 +1,348 @@
+import models from '../models';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const EMPTY_CURSOR_ID = '00000000-0000-0000-0000-000000000000';
+
+const normalizeLimit = (value) => {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(parsed, MAX_LIMIT);
+};
+
+const normalizeDate = (value) => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const uniqueStrings = values => [...new Set(values.filter(Boolean).map(String))];
+
+const readMetadataLocationFallback = (change) => {
+  if (change.field_name === 'location_id') {
+    return change.replacement_value || change.previous_value || null;
+  }
+  return change.previous_value || change.replacement_value || null;
+};
+
+export const serializeLocationChangesCursor = ({ createdAt, changeId = EMPTY_CURSOR_ID }) => {
+  const normalizedDate = normalizeDate(createdAt);
+  if (!normalizedDate) {
+    return null;
+  }
+  return `${normalizedDate.toISOString()}|${changeId || EMPTY_CURSOR_ID}`;
+};
+
+export const parseLocationChangesCursor = (cursor) => {
+  if (!cursor || typeof cursor !== 'string') {
+    return null;
+  }
+
+  const [createdAtText, changeId] = cursor.split('|');
+  const createdAt = normalizeDate(createdAtText);
+  if (!createdAt) {
+    return null;
+  }
+
+  return {
+    createdAt,
+    changeId: changeId || EMPTY_CURSOR_ID,
+  };
+};
+
+const resolveRequestedCursor = ({ cursor, since }) => {
+  const parsedCursor = parseLocationChangesCursor(cursor);
+  if (parsedCursor) {
+    return parsedCursor;
+  }
+
+  const sinceDate = normalizeDate(since);
+  if (sinceDate) {
+    return {
+      createdAt: sinceDate,
+      changeId: EMPTY_CURSOR_ID,
+    };
+  }
+
+  return {
+    createdAt: new Date(),
+    changeId: EMPTY_CURSOR_ID,
+  };
+};
+
+const makeResolverContext = () => ({
+  locationIdsByOrganizationId: new Map(),
+  locationIdsByServiceId: new Map(),
+  locationIdsByServiceAtLocationId: new Map(),
+  locationIdsByModelAndId: new Map(),
+});
+
+const cacheModelLookup = async (context, cacheKey, load) => {
+  if (context.locationIdsByModelAndId.has(cacheKey)) {
+    return context.locationIdsByModelAndId.get(cacheKey);
+  }
+  const value = uniqueStrings(await load());
+  context.locationIdsByModelAndId.set(cacheKey, value);
+  return value;
+};
+
+const getOrganizationLocationIds = async (organizationId, context) => {
+  const normalizedId = organizationId ? String(organizationId) : '';
+  if (!normalizedId) return [];
+  if (context.locationIdsByOrganizationId.has(normalizedId)) {
+    return context.locationIdsByOrganizationId.get(normalizedId);
+  }
+
+  const locations = await models.Location.findAll({
+    where: { organization_id: normalizedId },
+    attributes: ['id'],
+    raw: true,
+  });
+  const locationIds = uniqueStrings(locations.map(({ id }) => id));
+  context.locationIdsByOrganizationId.set(normalizedId, locationIds);
+  return locationIds;
+};
+
+const getServiceLocationIds = async (serviceId, context) => {
+  const normalizedId = serviceId ? String(serviceId) : '';
+  if (!normalizedId) return [];
+  if (context.locationIdsByServiceId.has(normalizedId)) {
+    return context.locationIdsByServiceId.get(normalizedId);
+  }
+
+  const serviceAtLocations = await models.ServiceAtLocation.findAll({
+    where: { service_id: normalizedId },
+    attributes: ['location_id'],
+    raw: true,
+  });
+  const locationIds = uniqueStrings(serviceAtLocations.map(({ location_id: locationId }) => locationId));
+  context.locationIdsByServiceId.set(normalizedId, locationIds);
+  return locationIds;
+};
+
+const getServiceAtLocationIds = async (serviceAtLocationId, context) => {
+  const normalizedId = serviceAtLocationId ? String(serviceAtLocationId) : '';
+  if (!normalizedId) return [];
+  if (context.locationIdsByServiceAtLocationId.has(normalizedId)) {
+    return context.locationIdsByServiceAtLocationId.get(normalizedId);
+  }
+
+  const record = await models.ServiceAtLocation.findByPk(normalizedId, {
+    attributes: ['location_id'],
+    raw: true,
+  });
+  const locationIds = uniqueStrings([record && record.location_id]);
+  context.locationIdsByServiceAtLocationId.set(normalizedId, locationIds);
+  return locationIds;
+};
+
+const getDirectLocationIds = async (context, resourceTable, resourceId, model, foreignKey = 'location_id') =>
+  cacheModelLookup(context, `${resourceTable}:${resourceId}`, async () => {
+    const record = await model.findByPk(resourceId, {
+      attributes: [foreignKey],
+      raw: true,
+    });
+    return [record && record[foreignKey]];
+  });
+
+const getOrganizationBackedLocationIds = async (context, resourceTable, resourceId, model) =>
+  cacheModelLookup(context, `${resourceTable}:${resourceId}`, async () => {
+    const record = await model.findByPk(resourceId, {
+      attributes: ['organization_id'],
+      raw: true,
+    });
+    return getOrganizationLocationIds(record && record.organization_id, context);
+  });
+
+const getServiceBackedLocationIds = async (context, resourceTable, resourceId, model) =>
+  cacheModelLookup(context, `${resourceTable}:${resourceId}`, async () => {
+    const record = await model.findByPk(resourceId, {
+      attributes: ['service_id'],
+      raw: true,
+    });
+    return getServiceLocationIds(record && record.service_id, context);
+  });
+
+const getScheduleBackedLocationIds = async (context, resourceTable, resourceId, model) =>
+  cacheModelLookup(context, `${resourceTable}:${resourceId}`, async () => {
+    const record = await model.findByPk(resourceId, {
+      attributes: ['location_id', 'service_id', 'service_at_location_id'],
+      raw: true,
+    });
+
+    return uniqueStrings([
+      record && record.location_id,
+      ...(await getServiceAtLocationIds(record && record.service_at_location_id, context)),
+      ...(await getServiceLocationIds(record && record.service_id, context)),
+    ]);
+  });
+
+const getPhoneLocationIds = async (resourceId, context) =>
+  cacheModelLookup(context, `phones:${resourceId}`, async () => {
+    const phone = await models.Phone.findByPk(resourceId, {
+      attributes: ['location_id', 'service_id', 'service_at_location_id', 'organization_id'],
+      raw: true,
+    });
+
+    return uniqueStrings([
+      phone && phone.location_id,
+      ...(await getServiceAtLocationIds(phone && phone.service_at_location_id, context)),
+      ...(await getServiceLocationIds(phone && phone.service_id, context)),
+      ...(await getOrganizationLocationIds(phone && phone.organization_id, context)),
+    ]);
+  });
+
+const getEventRelatedInfoLocationIds = async (resourceId, context) =>
+  cacheModelLookup(context, `event_related_info:${resourceId}`, async () => {
+    const record = await models.EventRelatedInfo.findByPk(resourceId, {
+      attributes: ['location_id', 'service_id'],
+      raw: true,
+    });
+
+    return uniqueStrings([
+      record && record.location_id,
+      ...(await getServiceLocationIds(record && record.service_id, context)),
+    ]);
+  });
+
+const resolveLocationIdsForChange = async (change, context) => {
+  switch (change.resource_table) {
+    case 'locations':
+      return uniqueStrings([change.resource_id]);
+    case 'organizations':
+      return getOrganizationLocationIds(change.resource_id, context);
+    case 'physical_addresses':
+      return getDirectLocationIds(context, 'physical_addresses', change.resource_id, models.PhysicalAddress);
+    case 'accessibility_for_disabilities':
+      return getDirectLocationIds(
+        context,
+        'accessibility_for_disabilities',
+        change.resource_id,
+        models.AccessibilityForDisabilities,
+      );
+    case 'location_languages':
+      return getDirectLocationIds(context, 'location_languages', change.resource_id, models.LocationLanguages);
+    case 'phones':
+      return getPhoneLocationIds(change.resource_id, context);
+    case 'event_related_info':
+      return getEventRelatedInfoLocationIds(change.resource_id, context);
+    case 'services':
+      return getServiceLocationIds(change.resource_id, context);
+    case 'service_at_locations':
+      return uniqueStrings([
+        ...(await getServiceAtLocationIds(change.resource_id, context)),
+        readMetadataLocationFallback(change),
+      ]);
+    case 'regular_schedules':
+      return getScheduleBackedLocationIds(context, 'regular_schedules', change.resource_id, models.RegularSchedule);
+    case 'holiday_schedules':
+      return getScheduleBackedLocationIds(context, 'holiday_schedules', change.resource_id, models.HolidaySchedule);
+    case 'service_areas':
+      return getServiceBackedLocationIds(context, 'service_areas', change.resource_id, models.ServiceArea);
+    case 'eligibility':
+      return getServiceBackedLocationIds(context, 'eligibility', change.resource_id, models.Eligibility);
+    case 'service_taxonomy_specific_attributes':
+      return getServiceBackedLocationIds(
+        context,
+        'service_taxonomy_specific_attributes',
+        change.resource_id,
+        models.ServiceTaxonomySpecificAttribute,
+      );
+    case 'required_documents':
+      return getServiceBackedLocationIds(
+        context,
+        'required_documents',
+        change.resource_id,
+        models.RequiredDocument,
+      );
+    case 'documents_infos':
+      return getServiceBackedLocationIds(context, 'documents_infos', change.resource_id, models.DocumentsInfo);
+    case 'service_languages':
+      return getServiceBackedLocationIds(context, 'service_languages', change.resource_id, models.ServiceLanguages);
+    case 'service_taxonomy':
+      return getServiceBackedLocationIds(context, 'service_taxonomy', change.resource_id, models.ServiceTaxonomy);
+    case 'comments':
+      return getDirectLocationIds(context, 'comments', change.resource_id, models.Comment);
+    case 'error_reports':
+      return getDirectLocationIds(context, 'error_reports', change.resource_id, models.ErrorReport);
+    case 'organization_phones':
+      return getOrganizationBackedLocationIds(context, 'organization_phones', change.resource_id, models.Phone);
+    default:
+      return [];
+  }
+};
+
+const fetchMetadataChanges = ({ createdAt, changeId, limit }) =>
+  models.sequelize.query(
+    `
+      select *
+      from metadata
+      where (
+        created_at > $1
+        or (created_at = $1 and id > $2)
+      )
+      order by created_at asc, id asc
+      limit $3
+    `,
+    {
+      bind: [createdAt.toISOString(), changeId, limit + 1],
+      type: models.Sequelize.QueryTypes.SELECT,
+    },
+  );
+
+export const getLocationChanges = async ({ cursor, since, limit } = {}) => {
+  const requestedCursor = resolveRequestedCursor({ cursor, since });
+  const normalizedLimit = normalizeLimit(limit);
+  const rows = await fetchMetadataChanges({
+    createdAt: requestedCursor.createdAt,
+    changeId: requestedCursor.changeId,
+    limit: normalizedLimit,
+  });
+  const hasMore = rows.length > normalizedLimit;
+  const trimmedRows = hasMore ? rows.slice(0, normalizedLimit) : rows;
+  const context = makeResolverContext();
+  const expandedChanges = [];
+
+  for (const row of trimmedRows) {
+    const locationIds = await resolveLocationIdsForChange(row, context);
+    locationIds.forEach((locationId) => {
+      expandedChanges.push({
+        cursor: serializeLocationChangesCursor({
+          createdAt: row.created_at,
+          changeId: row.id,
+        }),
+        locationId,
+        changedAt: row.created_at,
+        actionAt: row.last_action_date,
+        actionType: row.last_action_type,
+        resourceTable: row.resource_table,
+        resourceId: row.resource_id,
+        fieldName: row.field_name,
+        source: row.source || null,
+      });
+    });
+  }
+
+  const nextCursor = trimmedRows.length
+    ? serializeLocationChangesCursor({
+      createdAt: trimmedRows[trimmedRows.length - 1].created_at,
+      changeId: trimmedRows[trimmedRows.length - 1].id,
+    })
+    : serializeLocationChangesCursor(requestedCursor);
+
+  return {
+    changes: expandedChanges,
+    locationIds: uniqueStrings(expandedChanges.map(({ locationId }) => locationId)),
+    nextCursor,
+    hasMore,
+    serverTime: new Date().toISOString(),
+  };
+};
+
+export default {
+  getLocationChanges,
+  parseLocationChangesCursor,
+  serializeLocationChangesCursor,
+};

--- a/src/services/location-changes.js
+++ b/src/services/location-changes.js
@@ -99,6 +99,7 @@ const getOrganizationLocationIds = async (organizationId, context) => {
     where: { organization_id: normalizedId },
     attributes: ['id'],
     raw: true,
+    hooks: false,
   });
   const locationIds = uniqueStrings(locations.map(({ id }) => id));
   context.locationIdsByOrganizationId.set(normalizedId, locationIds);
@@ -117,7 +118,8 @@ const getServiceLocationIds = async (serviceId, context) => {
     attributes: ['location_id'],
     raw: true,
   });
-  const locationIds = uniqueStrings(serviceAtLocations.map(({ location_id: locationId }) => locationId));
+  const locationIds = uniqueStrings(serviceAtLocations
+    .map(serviceAtLocation => serviceAtLocation.location_id));
   context.locationIdsByServiceId.set(normalizedId, locationIds);
   return locationIds;
 };
@@ -138,7 +140,13 @@ const getServiceAtLocationIds = async (serviceAtLocationId, context) => {
   return locationIds;
 };
 
-const getDirectLocationIds = async (context, resourceTable, resourceId, model, foreignKey = 'location_id') =>
+const getDirectLocationIds = async (
+  context,
+  resourceTable,
+  resourceId,
+  model,
+  foreignKey = 'location_id',
+) =>
   cacheModelLookup(context, `${resourceTable}:${resourceId}`, async () => {
     const record = await model.findByPk(resourceId, {
       attributes: [foreignKey],
@@ -179,7 +187,7 @@ const getScheduleBackedLocationIds = async (context, resourceTable, resourceId, 
     ]);
   });
 
-const getPhoneLocationIds = async (resourceId, context) =>
+const getPersistedPhoneLocationIds = async (resourceId, context) =>
   cacheModelLookup(context, `phones:${resourceId}`, async () => {
     const phone = await models.Phone.findByPk(resourceId, {
       attributes: ['location_id', 'service_id', 'service_at_location_id', 'organization_id'],
@@ -193,6 +201,12 @@ const getPhoneLocationIds = async (resourceId, context) =>
       ...(await getOrganizationLocationIds(phone && phone.organization_id, context)),
     ]);
   });
+
+const getPhoneLocationIds = async (change, context) =>
+  uniqueStrings([
+    ...(await getPersistedPhoneLocationIds(change.resource_id, context)),
+    readMetadataLocationFallback(change),
+  ]);
 
 const getEventRelatedInfoLocationIds = async (resourceId, context) =>
   cacheModelLookup(context, `event_related_info:${resourceId}`, async () => {
@@ -214,7 +228,12 @@ const resolveLocationIdsForChange = async (change, context) => {
     case 'organizations':
       return getOrganizationLocationIds(change.resource_id, context);
     case 'physical_addresses':
-      return getDirectLocationIds(context, 'physical_addresses', change.resource_id, models.PhysicalAddress);
+      return getDirectLocationIds(
+        context,
+        'physical_addresses',
+        change.resource_id,
+        models.PhysicalAddress,
+      );
     case 'accessibility_for_disabilities':
       return getDirectLocationIds(
         context,
@@ -223,9 +242,14 @@ const resolveLocationIdsForChange = async (change, context) => {
         models.AccessibilityForDisabilities,
       );
     case 'location_languages':
-      return getDirectLocationIds(context, 'location_languages', change.resource_id, models.LocationLanguages);
+      return getDirectLocationIds(
+        context,
+        'location_languages',
+        change.resource_id,
+        models.LocationLanguages,
+      );
     case 'phones':
-      return getPhoneLocationIds(change.resource_id, context);
+      return getPhoneLocationIds(change, context);
     case 'event_related_info':
       return getEventRelatedInfoLocationIds(change.resource_id, context);
     case 'services':
@@ -236,13 +260,33 @@ const resolveLocationIdsForChange = async (change, context) => {
         readMetadataLocationFallback(change),
       ]);
     case 'regular_schedules':
-      return getScheduleBackedLocationIds(context, 'regular_schedules', change.resource_id, models.RegularSchedule);
+      return getScheduleBackedLocationIds(
+        context,
+        'regular_schedules',
+        change.resource_id,
+        models.RegularSchedule,
+      );
     case 'holiday_schedules':
-      return getScheduleBackedLocationIds(context, 'holiday_schedules', change.resource_id, models.HolidaySchedule);
+      return getScheduleBackedLocationIds(
+        context,
+        'holiday_schedules',
+        change.resource_id,
+        models.HolidaySchedule,
+      );
     case 'service_areas':
-      return getServiceBackedLocationIds(context, 'service_areas', change.resource_id, models.ServiceArea);
+      return getServiceBackedLocationIds(
+        context,
+        'service_areas',
+        change.resource_id,
+        models.ServiceArea,
+      );
     case 'eligibility':
-      return getServiceBackedLocationIds(context, 'eligibility', change.resource_id, models.Eligibility);
+      return getServiceBackedLocationIds(
+        context,
+        'eligibility',
+        change.resource_id,
+        models.Eligibility,
+      );
     case 'service_taxonomy_specific_attributes':
       return getServiceBackedLocationIds(
         context,
@@ -258,17 +302,37 @@ const resolveLocationIdsForChange = async (change, context) => {
         models.RequiredDocument,
       );
     case 'documents_infos':
-      return getServiceBackedLocationIds(context, 'documents_infos', change.resource_id, models.DocumentsInfo);
+      return getServiceBackedLocationIds(
+        context,
+        'documents_infos',
+        change.resource_id,
+        models.DocumentsInfo,
+      );
     case 'service_languages':
-      return getServiceBackedLocationIds(context, 'service_languages', change.resource_id, models.ServiceLanguages);
+      return getServiceBackedLocationIds(
+        context,
+        'service_languages',
+        change.resource_id,
+        models.ServiceLanguages,
+      );
     case 'service_taxonomy':
-      return getServiceBackedLocationIds(context, 'service_taxonomy', change.resource_id, models.ServiceTaxonomy);
+      return getServiceBackedLocationIds(
+        context,
+        'service_taxonomy',
+        change.resource_id,
+        models.ServiceTaxonomy,
+      );
     case 'comments':
       return getDirectLocationIds(context, 'comments', change.resource_id, models.Comment);
     case 'error_reports':
       return getDirectLocationIds(context, 'error_reports', change.resource_id, models.ErrorReport);
     case 'organization_phones':
-      return getOrganizationBackedLocationIds(context, 'organization_phones', change.resource_id, models.Phone);
+      return getOrganizationBackedLocationIds(
+        context,
+        'organization_phones',
+        change.resource_id,
+        models.Phone,
+      );
     default:
       return [];
   }

--- a/src/services/location-changes.js
+++ b/src/services/location-changes.js
@@ -19,6 +19,21 @@ const normalizeDate = (value) => {
 };
 
 const uniqueStrings = values => [...new Set(values.filter(Boolean).map(String))];
+const normalizeAllowedLocationIds = (allowedLocationIds) => {
+  if (allowedLocationIds == null) {
+    return null;
+  }
+
+  if (allowedLocationIds instanceof Set) {
+    return new Set(uniqueStrings([...allowedLocationIds]));
+  }
+
+  if (Array.isArray(allowedLocationIds)) {
+    return new Set(uniqueStrings(allowedLocationIds));
+  }
+
+  return new Set(uniqueStrings([allowedLocationIds]));
+};
 
 const readMetadataLocationFallback = (change) => {
   if (change.field_name === 'location_id') {
@@ -356,9 +371,25 @@ const fetchMetadataChanges = ({ createdAt, changeId, limit }) =>
     },
   );
 
-export const getLocationChanges = async ({ cursor, since, limit } = {}) => {
+export const getLocationChanges = async ({
+  cursor,
+  since,
+  limit,
+  allowedLocationIds = null,
+} = {}) => {
   const requestedCursor = resolveRequestedCursor({ cursor, since });
   const normalizedLimit = normalizeLimit(limit);
+  const allowedLocationIdSet = normalizeAllowedLocationIds(allowedLocationIds);
+  if (allowedLocationIdSet && !allowedLocationIdSet.size) {
+    return {
+      changes: [],
+      locationIds: [],
+      nextCursor: serializeLocationChangesCursor(requestedCursor),
+      hasMore: false,
+      serverTime: new Date().toISOString(),
+    };
+  }
+
   const rows = await fetchMetadataChanges({
     createdAt: requestedCursor.createdAt,
     changeId: requestedCursor.changeId,
@@ -371,7 +402,10 @@ export const getLocationChanges = async ({ cursor, since, limit } = {}) => {
 
   for (const row of trimmedRows) {
     const locationIds = await resolveLocationIdsForChange(row, context);
-    locationIds.forEach((locationId) => {
+    const visibleLocationIds = allowedLocationIdSet
+      ? locationIds.filter(locationId => allowedLocationIdSet.has(String(locationId)))
+      : locationIds;
+    visibleLocationIds.forEach((locationId) => {
       expandedChanges.push({
         cursor: serializeLocationChangesCursor({
           createdAt: row.created_at,

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -73,6 +73,28 @@ const updateLanguages = async (service, languageIds, { t, user, metadata }) => {
   }, { transaction: t, metadata })));
 };
 
+const updateTaxonomy = async (service, taxonomy, { t, user, metadata }) => {
+  const currentTaxonomies = await models.ServiceTaxonomy.findAll({
+    where: { service_id: service.id },
+    transaction: t,
+  });
+  const currentTaxonomyIds = currentTaxonomies
+    .map(({ taxonomy_id: taxonomyId }) => taxonomyId)
+    .filter(Boolean);
+
+  if (currentTaxonomyIds.length === 1 && currentTaxonomyIds[0] === taxonomy.id) {
+    return;
+  }
+
+  await Promise.all(currentTaxonomies.map((currentTaxonomy) =>
+    destroyInstance(user, currentTaxonomy, { transaction: t })));
+
+  await createInstance(user, models.ServiceTaxonomy.create.bind(models.ServiceTaxonomy), {
+    service_id: service.id,
+    taxonomy_id: taxonomy.id,
+  }, { transaction: t, metadata });
+};
+
 const updateServiceAreas = async (service, area, { t, user, metadata }) => {
   const { postal_codes: postalCodes } = area;
 
@@ -240,7 +262,7 @@ export const updateService = (
   const updatePromises = [];
 
   if (taxonomy) {
-    updatePromises.push(service.setTaxonomies([taxonomy], { transaction: t }));
+    updatePromises.push(updateTaxonomy(service, taxonomy, { t, user, metadata }));
   }
 
   if (hours) {

--- a/test/integration/edit-history.test.js
+++ b/test/integration/edit-history.test.js
@@ -2,13 +2,46 @@
  * @jest-environment node
  */
 
+import bodyParser from 'body-parser';
+import { randomUUID } from 'crypto';
+import express from 'express';
 import request from 'supertest';
 import app from '../../src/app';
+import locations from '../../src/controllers/locations';
+import getUser from '../../src/middleware/get-user';
 import models from '../../src/models';
+import { buildHistoryUserIdentity } from '../../src/services/edit-history';
 
 describe('edit history', () => {
   const timelineTestName =
     'returns extension-style timeline pages for service description and other info edits';
+  const buildAuthenticatedHistoryApp = (claims) => {
+    const authenticatedApp = express();
+    authenticatedApp.use(bodyParser.json());
+    authenticatedApp.use((req, res, next) => {
+      req.apiGateway = {
+        event: {
+          requestContext: {
+            authorizer: { claims },
+          },
+        },
+      };
+      next();
+    });
+    authenticatedApp.get(
+      '/locations/edit-history/user',
+      getUser,
+      locations.getCurrentUserEditHistory,
+    );
+    authenticatedApp.use((err, req, res, next) => {
+      if (res.headersSent) {
+        return next(err);
+      }
+
+      return res.status(500).send({ error: err.stack });
+    });
+    return authenticatedApp;
+  };
   const runAsProduction = async (callback) => {
     const originalNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
@@ -217,6 +250,81 @@ describe('edit history', () => {
         .get('/locations/edit-history/user')
         .expect(401);
     });
+  });
+
+  it('keeps email-based Cognito identities isolated in current user history', async () => {
+    const locationId = randomUUID();
+    const otherLocationId = randomUUID();
+    const claims = {
+      sub: randomUUID(),
+      'cognito:username': 'editor@example.org',
+    };
+    const otherClaims = {
+      sub: randomUUID(),
+      'cognito:username': 'other@example.org',
+    };
+    const identity = buildHistoryUserIdentity({
+      userKey: claims.sub,
+      userName: claims['cognito:username'],
+    });
+    const otherIdentity = buildHistoryUserIdentity({
+      userKey: otherClaims.sub,
+      userName: otherClaims['cognito:username'],
+    });
+
+    await models.EditHistory.bulkCreate([
+      {
+        location_id: locationId,
+        page_path: `/team/location/${locationId}`,
+        user_key: identity.key,
+        user_name: identity.displayName,
+        action: 'update',
+        field: 'description',
+        label: 'Description',
+        before_value: 'Before',
+        after_value: 'After',
+        summary: 'Updated Description',
+        resource_table: 'locations',
+        resource_id: locationId,
+        source: 'location-api',
+        action_at: new Date(),
+        copyedit: false,
+      },
+      {
+        location_id: otherLocationId,
+        page_path: `/team/location/${otherLocationId}`,
+        user_key: otherIdentity.key,
+        user_name: otherIdentity.displayName,
+        action: 'update',
+        field: 'description',
+        label: 'Description',
+        before_value: 'Before',
+        after_value: 'After',
+        summary: 'Updated Description',
+        resource_table: 'locations',
+        resource_id: otherLocationId,
+        source: 'location-api',
+        action_at: new Date(),
+        copyedit: false,
+      },
+    ]);
+
+    const response = await request(buildAuthenticatedHistoryApp(claims))
+      .get('/locations/edit-history/user')
+      .expect(200);
+
+    expect(response.body.user).toEqual(expect.objectContaining({
+      key: identity.displayName,
+      name: identity.displayName,
+    }));
+    expect(response.body.user.name).not.toBe('Unknown');
+    expect(response.body.data[`/team/location/${locationId}`]).toBeDefined();
+    expect(response.body.data[`/team/location/${otherLocationId}`]).toBeUndefined();
+    expect(Object.values(response.body.data[`/team/location/${locationId}`])[0])
+      .toEqual(expect.objectContaining({
+        userName: identity.displayName,
+        pagePath: `/team/location/${locationId}`,
+      }));
   });
 
   it('still updates a location when history recording fails', async () => {

--- a/test/integration/edit-history.test.js
+++ b/test/integration/edit-history.test.js
@@ -9,6 +9,16 @@ import models from '../../src/models';
 describe('edit history', () => {
   const timelineTestName =
     'returns extension-style timeline pages for service description and other info edits';
+  const runAsProduction = async (callback) => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      await callback();
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  };
 
   const buildFixture = async () => {
     const organization = await models.Organization.create(
@@ -185,6 +195,28 @@ describe('edit history', () => {
       label: 'Description',
       pagePath: descriptionPath,
     }));
+  });
+
+  it('rejects unauthenticated edit history endpoints outside test mode', async () => {
+    const { location } = await buildFixture();
+
+    await runAsProduction(async () => {
+      await request(app)
+        .get(`/locations/${location.id}/edit-history`)
+        .expect(401);
+
+      await request(app)
+        .get('/locations/edit-history/timeline')
+        .query({
+          locationId: location.id,
+          scope: 'location',
+        })
+        .expect(401);
+
+      await request(app)
+        .get('/locations/edit-history/user')
+        .expect(401);
+    });
   });
 
   it('still updates a location when history recording fails', async () => {

--- a/test/integration/edit-history.test.js
+++ b/test/integration/edit-history.test.js
@@ -1,0 +1,189 @@
+/**
+ * @jest-environment node
+ */
+
+import request from 'supertest';
+import app from '../../src/app';
+import models from '../../src/models';
+
+describe('edit history', () => {
+  const timelineTestName =
+    'returns extension-style timeline pages for service description and other info edits';
+
+  const buildFixture = async () => {
+    const organization = await models.Organization.create(
+      {
+        name: 'Edit History Org',
+        description: 'Org for edit history tests.',
+        url: 'https://example.org',
+        Services: [{
+          name: 'Testing service',
+          description: 'Service description.',
+          Taxonomies: [{
+            name: 'Shelter',
+          }],
+        }],
+        Locations: [{
+          name: 'History test location',
+          description: 'Location description.',
+          hidden_from_search: true,
+          PhysicalAddresses: [{
+            address_1: '123 Test Street',
+            city: 'New York',
+            state_province: 'NY',
+            postal_code: '10001',
+            country: 'United States',
+          }],
+          Phones: [{
+            number: '2125550101',
+          }],
+        }],
+      },
+      {
+        include: [
+          { model: models.Service, include: [{ model: models.Taxonomy }] },
+          {
+            model: models.Location,
+            include: [
+              { model: models.PhysicalAddress },
+              { model: models.Phone },
+            ],
+          },
+        ],
+      },
+    );
+
+    const location = organization.Locations[0];
+    const service = organization.Services[0];
+    const phone = location.Phones[0];
+
+    await location.setServices([service]);
+    await models.DocumentsInfo.create({ service_id: service.id });
+
+    return {
+      organization,
+      location,
+      service,
+      phone,
+    };
+  };
+
+  afterEach(async () => {
+    await models.EditHistory.destroy({ where: {} });
+  });
+
+  it('records location and organization edits on the location history endpoint', async () => {
+    const { organization, location } = await buildFixture();
+
+    await request(app)
+      .patch(`/organizations/${organization.id}`)
+      .send({ description: 'Updated org description.' })
+      .expect(204);
+
+    await request(app)
+      .patch(`/locations/${location.id}`)
+      .send({
+        name: 'Updated location name',
+        address: {
+          street: '456 Updated Street',
+        },
+      })
+      .expect(204);
+
+    const response = await request(app)
+      .get(`/locations/${location.id}/edit-history`)
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.locationId).toBe(location.id);
+    expect(response.body.edits.length).toBeGreaterThanOrEqual(3);
+    expect(response.body.edits[0]).toEqual(expect.objectContaining({
+      type: 'edit',
+      userName: '<Anonymous>',
+      pagePath: `/team/location/${location.id}`,
+    }));
+    expect(response.body.edits.map(edit => edit.resourceTable)).toEqual(expect.arrayContaining([
+      'locations',
+      'organizations',
+    ]));
+    expect(response.body.edits.map(edit => edit.label)).toEqual(expect.arrayContaining([
+      'Name',
+      'Street',
+      'Description',
+    ]));
+  });
+
+  it(timelineTestName, async () => {
+    const { location, service } = await buildFixture();
+
+    await request(app)
+      .patch(`/services/${service.id}`)
+      .send({
+        description: 'Updated service description.',
+        eventRelatedInfo: {
+          event: 'COVID19',
+          information: 'Bring a government ID.',
+        },
+      })
+      .expect(204);
+
+    const response = await request(app)
+      .get('/locations/edit-history/timeline')
+      .query({
+        locationId: location.id,
+        scope: 'location',
+        includeSegments: true,
+      })
+      .expect(200);
+
+    const descriptionPath = `/team/location/${location.id}/services/${service.id}/description`;
+    const otherInfoPath = `/team/location/${location.id}/services/${service.id}/other-info`;
+    const descriptionKey = encodeURIComponent(descriptionPath);
+    const otherInfoKey = encodeURIComponent(otherInfoPath);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.pages[descriptionKey]).toBeDefined();
+    expect(response.body.pages[otherInfoKey]).toBeDefined();
+    expect(response.body.pages[descriptionKey].fieldKey).toBe('services.description');
+    expect(response.body.pages[otherInfoKey].fieldKey).toBe('services.additional_info');
+    expect(response.body.pages[descriptionKey].events[0]).toEqual(expect.objectContaining({
+      label: 'Description',
+      pagePath: descriptionPath,
+      userName: '<Anonymous>',
+    }));
+    expect(Array.isArray(response.body.pages[descriptionKey].events[0].segments)).toBe(true);
+  });
+
+  it('groups the current user history by page path', async () => {
+    const { location, service } = await buildFixture();
+
+    await request(app)
+      .patch(`/locations/${location.id}`)
+      .send({ description: 'Refreshed location description.' })
+      .expect(204);
+
+    await request(app)
+      .patch(`/services/${service.id}`)
+      .send({ description: 'Refreshed service description.' })
+      .expect(204);
+
+    const response = await request(app)
+      .get('/locations/edit-history/user')
+      .expect(200);
+
+    const locationPath = `/team/location/${location.id}`;
+    const descriptionPath = `/team/location/${location.id}/services/${service.id}/description`;
+
+    expect(response.body.user).toEqual(expect.objectContaining({
+      key: '<Anonymous>',
+      name: '<Anonymous>',
+    }));
+    expect(response.body.data[locationPath]).toBeDefined();
+    expect(response.body.data[descriptionPath]).toBeDefined();
+    expect(Object.values(response.body.data[descriptionPath])[0]).toEqual(expect.objectContaining({
+      userName: '<Anonymous>',
+      label: 'Description',
+      pagePath: descriptionPath,
+    }));
+  });
+});

--- a/test/integration/edit-history.test.js
+++ b/test/integration/edit-history.test.js
@@ -6,16 +6,14 @@ import bodyParser from 'body-parser';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
-import app from '../../src/app';
-import locations from '../../src/controllers/locations';
-import getUser from '../../src/middleware/get-user';
+import apiApp from '../../src/app';
 import models from '../../src/models';
 import { buildHistoryUserIdentity } from '../../src/services/edit-history';
 
 describe('edit history', () => {
   const timelineTestName =
     'returns extension-style timeline pages for service description and other info edits';
-  const buildAuthenticatedHistoryApp = (claims) => {
+  const buildAuthenticatedApp = (claims) => {
     const authenticatedApp = express();
     authenticatedApp.use(bodyParser.json());
     authenticatedApp.use((req, res, next) => {
@@ -28,18 +26,7 @@ describe('edit history', () => {
       };
       next();
     });
-    authenticatedApp.get(
-      '/locations/edit-history/user',
-      getUser,
-      locations.getCurrentUserEditHistory,
-    );
-    authenticatedApp.use((err, req, res, next) => {
-      if (res.headersSent) {
-        return next(err);
-      }
-
-      return res.status(500).send({ error: err.stack });
-    });
+    authenticatedApp.use(apiApp);
     return authenticatedApp;
   };
   const runAsProduction = async (callback) => {
@@ -118,12 +105,12 @@ describe('edit history', () => {
   it('records location and organization edits on the location history endpoint', async () => {
     const { organization, location } = await buildFixture();
 
-    await request(app)
+    await request(apiApp)
       .patch(`/organizations/${organization.id}`)
       .send({ description: 'Updated org description.' })
       .expect(204);
 
-    await request(app)
+    await request(apiApp)
       .patch(`/locations/${location.id}`)
       .send({
         name: 'Updated location name',
@@ -133,7 +120,7 @@ describe('edit history', () => {
       })
       .expect(204);
 
-    const response = await request(app)
+    const response = await request(apiApp)
       .get(`/locations/${location.id}/edit-history`)
       .expect(200);
 
@@ -159,7 +146,7 @@ describe('edit history', () => {
   it(timelineTestName, async () => {
     const { location, service } = await buildFixture();
 
-    await request(app)
+    await request(apiApp)
       .patch(`/services/${service.id}`)
       .send({
         description: 'Updated service description.',
@@ -170,7 +157,7 @@ describe('edit history', () => {
       })
       .expect(204);
 
-    const response = await request(app)
+    const response = await request(apiApp)
       .get('/locations/edit-history/timeline')
       .query({
         locationId: location.id,
@@ -185,6 +172,7 @@ describe('edit history', () => {
     const otherInfoKey = encodeURIComponent(otherInfoPath);
 
     expect(response.body.ok).toBe(true);
+    expect(response.body.scope).toBe('location');
     expect(response.body.pages[descriptionKey]).toBeDefined();
     expect(response.body.pages[otherInfoKey]).toBeDefined();
     expect(response.body.pages[descriptionKey].fieldKey).toBe('services.description');
@@ -200,17 +188,17 @@ describe('edit history', () => {
   it('groups the current user history by page path', async () => {
     const { location, service } = await buildFixture();
 
-    await request(app)
+    await request(apiApp)
       .patch(`/locations/${location.id}`)
       .send({ description: 'Refreshed location description.' })
       .expect(204);
 
-    await request(app)
+    await request(apiApp)
       .patch(`/services/${service.id}`)
       .send({ description: 'Refreshed service description.' })
       .expect(204);
 
-    const response = await request(app)
+    const response = await request(apiApp)
       .get('/locations/edit-history/user')
       .expect(200);
 
@@ -230,15 +218,27 @@ describe('edit history', () => {
     }));
   });
 
+  it('rejects unsupported timeline scopes', async () => {
+    const { location } = await buildFixture();
+
+    await request(apiApp)
+      .get('/locations/edit-history/timeline')
+      .query({
+        locationId: location.id,
+        scope: 'page',
+      })
+      .expect(400);
+  });
+
   it('rejects unauthenticated edit history endpoints outside test mode', async () => {
     const { location } = await buildFixture();
 
     await runAsProduction(async () => {
-      await request(app)
+      await request(apiApp)
         .get(`/locations/${location.id}/edit-history`)
         .expect(401);
 
-      await request(app)
+      await request(apiApp)
         .get('/locations/edit-history/timeline')
         .query({
           locationId: location.id,
@@ -246,9 +246,49 @@ describe('edit history', () => {
         })
         .expect(401);
 
-      await request(app)
+      await request(apiApp)
         .get('/locations/edit-history/user')
         .expect(401);
+    });
+  });
+
+  it('restricts location history reads to matching organizations outside test mode', async () => {
+    const { organization, location } = await buildFixture();
+    const authorizedClaims = {
+      sub: randomUUID(),
+      'cognito:username': 'authorized-editor',
+      'custom:orgs': organization.id,
+    };
+    const unauthorizedClaims = {
+      sub: randomUUID(),
+      'cognito:username': 'unauthorized-editor',
+      'custom:orgs': randomUUID(),
+    };
+
+    await runAsProduction(async () => {
+      await request(buildAuthenticatedApp(authorizedClaims))
+        .get(`/locations/${location.id}/edit-history`)
+        .expect(200);
+
+      await request(buildAuthenticatedApp(authorizedClaims))
+        .get('/locations/edit-history/timeline')
+        .query({
+          locationId: location.id,
+          scope: 'location',
+        })
+        .expect(200);
+
+      await request(buildAuthenticatedApp(unauthorizedClaims))
+        .get(`/locations/${location.id}/edit-history`)
+        .expect(403);
+
+      await request(buildAuthenticatedApp(unauthorizedClaims))
+        .get('/locations/edit-history/timeline')
+        .query({
+          locationId: location.id,
+          scope: 'location',
+        })
+        .expect(403);
     });
   });
 
@@ -309,7 +349,7 @@ describe('edit history', () => {
       },
     ]);
 
-    const response = await request(buildAuthenticatedHistoryApp(claims))
+    const response = await request(buildAuthenticatedApp(claims))
       .get('/locations/edit-history/user')
       .expect(200);
 
@@ -327,12 +367,92 @@ describe('edit history', () => {
       }));
   });
 
+  it('filters current user history to the caller organizations outside test mode', async () => {
+    const allowedFixture = await buildFixture();
+    const otherFixture = await buildFixture();
+    const claims = {
+      sub: randomUUID(),
+      'cognito:username': 'org-scoped-editor',
+      'custom:orgs': allowedFixture.organization.id,
+    };
+    const identity = buildHistoryUserIdentity({
+      userKey: claims.sub,
+      userName: claims['cognito:username'],
+    });
+
+    await models.EditHistory.bulkCreate([
+      {
+        location_id: allowedFixture.location.id,
+        page_path: `/team/location/${allowedFixture.location.id}`,
+        user_key: identity.key,
+        user_name: identity.displayName,
+        action: 'update',
+        field: 'description',
+        label: 'Description',
+        before_value: null,
+        after_value: null,
+        summary: 'Updated Description',
+        resource_table: 'locations',
+        resource_id: allowedFixture.location.id,
+        source: 'location-api',
+        action_at: new Date(),
+        copyedit: false,
+      },
+      {
+        location_id: otherFixture.location.id,
+        page_path: `/team/location/${otherFixture.location.id}`,
+        user_key: identity.key,
+        user_name: identity.displayName,
+        action: 'update',
+        field: 'description',
+        label: 'Description',
+        before_value: null,
+        after_value: null,
+        summary: 'Updated Description',
+        resource_table: 'locations',
+        resource_id: otherFixture.location.id,
+        source: 'location-api',
+        action_at: new Date(),
+        copyedit: false,
+      },
+    ]);
+
+    await runAsProduction(async () => {
+      const response = await request(buildAuthenticatedApp(claims))
+        .get('/locations/edit-history/user')
+        .expect(200);
+
+      expect(response.body.data[`/team/location/${allowedFixture.location.id}`]).toBeDefined();
+      expect(response.body.data[`/team/location/${otherFixture.location.id}`]).toBeUndefined();
+    });
+  });
+
+  it('redacts raw before and after values for non-playback edits', async () => {
+    const { location } = await buildFixture();
+
+    await request(apiApp)
+      .patch(`/locations/${location.id}`)
+      .send({ name: 'Redacted history name' })
+      .expect(204);
+
+    const response = await request(apiApp)
+      .get(`/locations/${location.id}/edit-history`)
+      .expect(200);
+
+    const nameEdit = response.body.edits.find(edit => edit.label === 'Name');
+    expect(nameEdit).toEqual(expect.objectContaining({
+      summary: 'Updated Name',
+    }));
+    expect(nameEdit.before).toBeUndefined();
+    expect(nameEdit.after).toBeUndefined();
+  });
+
   it('still updates a location when history recording fails', async () => {
     const { location } = await buildFixture();
     const bulkCreateSpy = jest.spyOn(models.EditHistory, 'bulkCreate')
       .mockRejectedValueOnce(new Error('history write failed'));
 
-    await request(app)
+    await request(apiApp)
       .patch(`/locations/${location.id}`)
       .send({ description: 'Location saved despite history failure.' })
       .expect(204);
@@ -352,7 +472,7 @@ describe('edit history', () => {
     const bulkCreateSpy = jest.spyOn(models.EditHistory, 'bulkCreate')
       .mockRejectedValueOnce(new Error('history write failed'));
 
-    const response = await request(app)
+    const response = await request(apiApp)
       .post('/locations')
       .send({
         name: 'Created despite history failure',

--- a/test/integration/edit-history.test.js
+++ b/test/integration/edit-history.test.js
@@ -186,4 +186,53 @@ describe('edit history', () => {
       pagePath: descriptionPath,
     }));
   });
+
+  it('still updates a location when history recording fails', async () => {
+    const { location } = await buildFixture();
+    const bulkCreateSpy = jest.spyOn(models.EditHistory, 'bulkCreate')
+      .mockRejectedValueOnce(new Error('history write failed'));
+
+    await request(app)
+      .patch(`/locations/${location.id}`)
+      .send({ description: 'Location saved despite history failure.' })
+      .expect(204);
+
+    bulkCreateSpy.mockRestore();
+
+    const updatedLocation = await models.Location.findByPk(location.id);
+    expect(updatedLocation.description).toBe('Location saved despite history failure.');
+  });
+
+  it('still creates a location when history recording fails', async () => {
+    const organization = await models.Organization.create({
+      name: 'Create History Org',
+      description: 'Org for create history failure tests.',
+      url: 'https://example.org/create',
+    });
+    const bulkCreateSpy = jest.spyOn(models.EditHistory, 'bulkCreate')
+      .mockRejectedValueOnce(new Error('history write failed'));
+
+    const response = await request(app)
+      .post('/locations')
+      .send({
+        name: 'Created despite history failure',
+        description: 'Created description.',
+        latitude: 40.7128,
+        longitude: -74.0060,
+        organizationId: organization.id,
+        address: {
+          street: '789 Recovery Avenue',
+          city: 'New York',
+          state: 'NY',
+          postalCode: '10002',
+          country: 'United States',
+        },
+      })
+      .expect(201);
+
+    bulkCreateSpy.mockRestore();
+
+    const createdLocation = await models.Location.findByPk(response.body.id);
+    expect(createdLocation.name).toBe('Created despite history failure');
+  });
 });

--- a/test/integration/location-changes.test.js
+++ b/test/integration/location-changes.test.js
@@ -6,16 +6,27 @@ import request from 'supertest';
 import express from 'express';
 import locations from '../../src/controllers/locations';
 import models from '../../src/models';
+import getUser from '../../src/middleware/get-user';
 
 describe('location changes feed', () => {
   const app = express();
+  const runAsProduction = async (callback) => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      await callback();
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  };
   let organization;
   let location;
   let service;
   let phone;
 
   beforeAll(() => {
-    app.get('/locations/changes', locations.getChanges);
+    app.get('/locations/changes', getUser, locations.getChanges);
     app.delete('/phones/:phoneId', (req, res, next) => {
       req.user = '<Anonymous>';
       req.userName = '<Anonymous>';
@@ -164,5 +175,13 @@ describe('location changes feed', () => {
         actionType: 'delete',
       }),
     ]));
+  });
+
+  it('rejects unauthenticated access to the changes feed outside test mode', async () => {
+    await runAsProduction(async () => {
+      await request(app)
+        .get('/locations/changes')
+        .expect(401);
+    });
   });
 });

--- a/test/integration/location-changes.test.js
+++ b/test/integration/location-changes.test.js
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 
+import { randomUUID } from 'crypto';
 import request from 'supertest';
 import express from 'express';
 import locations from '../../src/controllers/locations';
@@ -10,6 +11,21 @@ import getUser from '../../src/middleware/get-user';
 
 describe('location changes feed', () => {
   const app = express();
+  const buildAuthenticatedChangesApp = (claims) => {
+    const authenticatedApp = express();
+    authenticatedApp.use((req, res, next) => {
+      req.apiGateway = {
+        event: {
+          requestContext: {
+            authorizer: { claims },
+          },
+        },
+      };
+      next();
+    });
+    authenticatedApp.use(app);
+    return authenticatedApp;
+  };
   const runAsProduction = async (callback) => {
     const originalNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
@@ -182,6 +198,49 @@ describe('location changes feed', () => {
       await request(app)
         .get('/locations/changes')
         .expect(401);
+    });
+  });
+
+  it('filters the changes feed to the caller organizations outside test mode', async () => {
+    const metadataDate = new Date(Date.now() - (60 * 1000));
+    const claims = {
+      sub: randomUUID(),
+      'cognito:username': 'authorized-editor',
+      'custom:orgs': organization.id,
+    };
+    const otherClaims = {
+      sub: randomUUID(),
+      'cognito:username': 'other-editor',
+      'custom:orgs': randomUUID(),
+    };
+
+    await models.Metadata.create({
+      resource_table: 'organizations',
+      resource_id: organization.id,
+      last_action_date: metadataDate,
+      last_action_type: models.Metadata.actionTypes.update,
+      field_name: 'name',
+      replacement_value: 'Scoped Changes Test Org',
+      createdAt: new Date(metadataDate.getTime() + 1000),
+      updatedAt: new Date(metadataDate.getTime() + 1000),
+    });
+
+    await runAsProduction(async () => {
+      const authorizedResponse = await request(buildAuthenticatedChangesApp(claims))
+        .get('/locations/changes')
+        .query({ since: new Date(metadataDate.getTime() - 1000).toISOString() })
+        .expect(200);
+
+      expect(authorizedResponse.body.locationIds).toEqual(expect.arrayContaining([location.id]));
+      expect(authorizedResponse.body.changes.length).toBeGreaterThan(0);
+
+      const unauthorizedResponse = await request(buildAuthenticatedChangesApp(otherClaims))
+        .get('/locations/changes')
+        .query({ since: new Date(metadataDate.getTime() - 1000).toISOString() })
+        .expect(200);
+
+      expect(unauthorizedResponse.body.locationIds).toEqual([]);
+      expect(unauthorizedResponse.body.changes).toEqual([]);
     });
   });
 });

--- a/test/integration/location-changes.test.js
+++ b/test/integration/location-changes.test.js
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+
+import request from 'supertest';
+import express from 'express';
+import locations from '../../src/controllers/locations';
+import models from '../../src/models';
+
+describe('location changes feed', () => {
+  const app = express();
+  let organization;
+  let location;
+  let service;
+  let phone;
+
+  beforeAll(() => {
+    app.get('/locations/changes', locations.getChanges);
+    app.use((err, req, res, next) => {
+      if (res.headersSent) {
+        return next(err);
+      }
+
+      return res.status(500).send({ error: err.stack });
+    });
+  });
+
+  beforeAll(async () => {
+    organization = await models.Organization.create(
+      {
+        name: 'Changes Test Org',
+        description: 'Org for location change feed tests.',
+        url: 'https://example.org',
+        Services: [{
+          name: 'Testing service',
+          description: 'Service description.',
+          Taxonomies: [{
+            name: 'Shelter',
+          }],
+        }],
+        Locations: [{
+          name: 'Feed test location',
+          description: 'Location description.',
+          hidden_from_search: true,
+          PhysicalAddresses: [{
+            address_1: '123 Test Street',
+            city: 'New York',
+            state_province: 'NY',
+            postal_code: '10001',
+            country: 'United States',
+          }],
+          Phones: [{
+            number: '2125550101',
+          }],
+        }],
+      },
+      {
+        include: [
+          { model: models.Service, include: [{ model: models.Taxonomy }] },
+          {
+            model: models.Location,
+            include: [
+              { model: models.PhysicalAddress },
+              { model: models.Phone },
+            ],
+          },
+        ],
+      },
+    );
+
+    [location] = organization.Locations;
+    [service] = organization.Services;
+    [phone] = location.Phones;
+
+    await location.setServices([service]);
+  });
+
+  it('resolves organization, service, and phone edits back to affected location ids', async () => {
+    const now = new Date();
+    const metadataDate = new Date(now.getTime() - 60 * 1000);
+
+    await models.Metadata.bulkCreate([
+      {
+        resource_table: 'organizations',
+        resource_id: organization.id,
+        last_action_date: metadataDate,
+        last_action_type: models.Metadata.actionTypes.update,
+        field_name: 'name',
+        replacement_value: 'Changes Test Org Updated',
+        createdAt: new Date(metadataDate.getTime() + 1000),
+        updatedAt: new Date(metadataDate.getTime() + 1000),
+      },
+      {
+        resource_table: 'phones',
+        resource_id: phone.id,
+        last_action_date: metadataDate,
+        last_action_type: models.Metadata.actionTypes.update,
+        field_name: 'number',
+        replacement_value: '2125550199',
+        createdAt: new Date(metadataDate.getTime() + 2000),
+        updatedAt: new Date(metadataDate.getTime() + 2000),
+      },
+      {
+        resource_table: 'services',
+        resource_id: service.id,
+        last_action_date: metadataDate,
+        last_action_type: models.Metadata.actionTypes.update,
+        field_name: 'description',
+        replacement_value: 'Updated service description.',
+        createdAt: new Date(metadataDate.getTime() + 3000),
+        updatedAt: new Date(metadataDate.getTime() + 3000),
+      },
+    ]);
+
+    const response = await request(app)
+      .get('/locations/changes')
+      .query({ since: new Date(metadataDate.getTime() - 1000).toISOString() })
+      .expect(200);
+
+    expect(response.body.locationIds).toEqual([location.id]);
+    expect(response.body.changes).toHaveLength(3);
+    expect(response.body.changes.map(change => change.resourceTable)).toEqual([
+      'organizations',
+      'phones',
+      'services',
+    ]);
+    expect(typeof response.body.nextCursor).toBe('string');
+  });
+
+  it('returns an empty bootstrap response when no cursor or since is provided', async () => {
+    const response = await request(app)
+      .get('/locations/changes')
+      .expect(200);
+
+    expect(response.body.changes).toEqual([]);
+    expect(response.body.locationIds).toEqual([]);
+    expect(typeof response.body.nextCursor).toBe('string');
+  });
+});

--- a/test/integration/location-changes.test.js
+++ b/test/integration/location-changes.test.js
@@ -16,6 +16,11 @@ describe('location changes feed', () => {
 
   beforeAll(() => {
     app.get('/locations/changes', locations.getChanges);
+    app.delete('/phones/:phoneId', (req, res, next) => {
+      req.user = '<Anonymous>';
+      req.userName = '<Anonymous>';
+      next();
+    }, locations.deletePhone);
     app.use((err, req, res, next) => {
       if (res.headersSent) {
         return next(err);
@@ -77,7 +82,7 @@ describe('location changes feed', () => {
 
   it('resolves organization, service, and phone edits back to affected location ids', async () => {
     const now = new Date();
-    const metadataDate = new Date(now.getTime() - 60 * 1000);
+    const metadataDate = new Date(now.getTime() - (60 * 1000));
 
     await models.Metadata.bulkCreate([
       {
@@ -135,5 +140,29 @@ describe('location changes feed', () => {
     expect(response.body.changes).toEqual([]);
     expect(response.body.locationIds).toEqual([]);
     expect(typeof response.body.nextCursor).toBe('string');
+  });
+
+  it('emits location ids for deleted phones', async () => {
+    const deletedPhoneId = phone.id;
+    const deleteStartedAt = new Date();
+
+    await request(app)
+      .delete(`/phones/${deletedPhoneId}`)
+      .expect(204);
+
+    const response = await request(app)
+      .get('/locations/changes')
+      .query({ since: new Date(deleteStartedAt.getTime() - 1000).toISOString() })
+      .expect(200);
+
+    expect(response.body.locationIds).toEqual(expect.arrayContaining([location.id]));
+    expect(response.body.changes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        locationId: location.id,
+        resourceTable: 'phones',
+        resourceId: deletedPhoneId,
+        actionType: 'delete',
+      }),
+    ]));
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -5,6 +5,7 @@ jest.setTimeout(10000);
 
 process.env.DATABASE_NAME = 'test';
 process.env.DATABASE_LOGGING = 'false';
+process.env.DATABASE_SSL = 'false';
 
 const models = require('../src/models');
 
@@ -25,6 +26,8 @@ async function execScript(script) {
 }
 
 beforeAll(async () => {
+  await models.sequelize.query('CREATE EXTENSION IF NOT EXISTS postgis;');
+
   // reset the database state
   await models.sequelize.query(`
     DO $$


### PR DESCRIPTION
## Summary
- add an authenticated edit history API backed by a new dit_history table
- record location, organization, service, and phone edits from API write paths using Cognito usernames
- expose extension-compatible user history and timeline endpoints for authenticated Cognito users

## Testing
- 
pm run build
- 
px eslint src/controllers/comments.js src/controllers/comment-highlights.js src/config.js test/setup.js src/services/edit-history.js test/integration/edit-history.test.js src/controllers/locations.js src/controllers/services.js src/controllers/organizations.js src/controllers/validation/locations.js src/middleware/get-user.js src/routes.js src/models/edit-history.js sequelize/migrations/20260318101500-create-edit-history.js
- 
px jest test/integration/edit-history.test.js --runInBand *(fails locally because the available PostgreSQL instance does not have the postgis extension package installed)*