### PR TITLE
Optimize location search by sequentially accumulating unique results with early exit

### DIFF
--- a/src/models/location.js
+++ b/src/models/location.js
@@ -455,49 +455,64 @@ module.exports = (sequelize, DataTypes, Op) => {
 
       const zipCodeCondition = { [Op.in]: parseZipCodes(searchString) };
 
-      // TODO: optimize this by stepping through the conditions until we have enough results
-      const searchResults = [
-        await findWithCondition({ '$PhysicalAddresses.postal_code$': zipCodeCondition }),
-        await findWithCondition(getPhoneNumberCondition(searchString)),
+      const searchConditions = [
+        { '$PhysicalAddresses.postal_code$': zipCodeCondition },
+        getPhoneNumberCondition(searchString),
 
-        await findWithCondition({ '$Organization.name$': exactExactMatchCondition }),
-        await findWithCondition({ '$Organization.name$': prefixCondition }),
-        await findWithCondition({ '$Organization.name_vector$': websearchToTsqueryCondition }),
-        await findWithCondition(getCombinedFuzzySearchCondition('Organization.name', searchString)),
-        await findWithCondition({ '$Location.name$': exactExactMatchCondition }),
-        await findWithCondition({ '$Location.name$': prefixCondition }),
-        await findWithCondition({ '$Location.name_vector$': websearchToTsqueryCondition }),
-        await findWithCondition(getCombinedFuzzySearchCondition('Location.name', searchString)),
+        { '$Organization.name$': exactExactMatchCondition },
+        { '$Organization.name$': prefixCondition },
+        { '$Organization.name_vector$': websearchToTsqueryCondition },
+        getCombinedFuzzySearchCondition('Organization.name', searchString),
+        { '$Location.name$': exactExactMatchCondition },
+        { '$Location.name$': prefixCondition },
+        { '$Location.name_vector$': websearchToTsqueryCondition },
+        getCombinedFuzzySearchCondition('Location.name', searchString),
 
-        await findWithCondition({ '$Services.name$': exactExactMatchCondition }),
-        await findWithCondition({ '$Services.Taxonomies.name$': exactExactMatchCondition }),
-        await findWithCondition({ '$Organization.name$': exactMatchCondition }),
-        await findWithCondition({ '$Location.name$': exactMatchCondition }),
-        await findWithCondition({ '$Services.name$': exactMatchCondition }),
-        await findWithCondition({ '$Services.Taxonomies.name$': exactMatchCondition }),
+        { '$Services.name$': exactExactMatchCondition },
+        { '$Services.Taxonomies.name$': exactExactMatchCondition },
+        { '$Organization.name$': exactMatchCondition },
+        { '$Location.name$': exactMatchCondition },
+        { '$Services.name$': exactMatchCondition },
+        { '$Services.Taxonomies.name$': exactMatchCondition },
 
         // prefix match
-        await findWithCondition({ '$Services.name$': prefixCondition }),
-        await findWithCondition({ '$Services.Taxonomies.name$': prefixCondition }),
+        { '$Services.name$': prefixCondition },
+        { '$Services.Taxonomies.name$': prefixCondition },
 
         // full-text search
-        await findWithCondition({ '$Services.name_vector$': websearchToTsqueryCondition }),
-        await findWithCondition({
+        { '$Services.name_vector$': websearchToTsqueryCondition },
+        {
           '$Services.Taxonomies.name_vector$': websearchToTsqueryCondition,
-        }),
+        },
 
-        await findWithCondition(getCombinedFuzzySearchCondition('Services.name', searchString)),
-        await findWithCondition(getCombinedFuzzySearchCondition(
+        getCombinedFuzzySearchCondition('Services.name', searchString),
+        getCombinedFuzzySearchCondition(
           'Services->Taxonomies.name',
           searchString,
-        )),
+        ),
         // full text search on the description
-        await findWithCondition({ '$Services.description_vector$': websearchToTsqueryCondition }),
+        { '$Services.description_vector$': websearchToTsqueryCondition },
+      ];
+      const accumulatedLocations = [];
+      const seenLocationIds = new Set();
+      const requiredResultCount = limit != null ? (offset || 0) + limit : Infinity;
 
-      ].reduce((a, b) => a.concat(b));
+      for (const condition of searchConditions) {
+        const matchedLocations = await findWithCondition(condition);
 
-      // Remove duplicates
-      locations = Array.from(new Map(searchResults.map(item => [item.id, item])).values());
+        matchedLocations.forEach((location) => {
+          if (!seenLocationIds.has(location.id)) {
+            seenLocationIds.add(location.id);
+            accumulatedLocations.push(location);
+          }
+        });
+
+        if (accumulatedLocations.length >= requiredResultCount) {
+          break;
+        }
+      }
+
+      locations = accumulatedLocations;
     } else {
       locations = await findAll(whereConditions);
     }

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -321,6 +321,23 @@ describe('find locations', () => {
       makeRequestWithSearchString('center')
         .expect(200)
         .then(expectMatchNearbyLocations));
+
+    it(
+      'should paginate unique search results when a search match appears in multiple queries',
+      () => makeRequestWithSearchString('center')
+        .query({
+          pageNumber: 1,
+          pageSize: 1,
+        })
+        .expect(200)
+        .then((res) => {
+          const returnedLocations = res.body;
+          expect(returnedLocations).toHaveLength(1);
+          expect(res.headers['total-count']).toBe('2');
+          expect(res.headers['pagination-count']).toBe('2');
+          checkLastValidatedAt(returnedLocations);
+        }),
+    );
   });
 
   describe('when an organization name is specified', () => {


### PR DESCRIPTION
### Motivation
- The previous implementation eagerly executed every search query in parallel and then deduplicated results, which is wasteful when pagination can be satisfied earlier. 
- The goal is to run search condition queries in order, accumulate unique location IDs, and stop as soon as enough unique results exist to satisfy `offset + limit` to reduce database work and RDS proxy session pinning.

### Description
- Replaced the eager `await` list of `findWithCondition(...)` calls with an ordered `searchConditions` array and a loop that calls `findWithCondition` sequentially. 
- Accumulate unique `Location` rows using a `Set` for seen IDs and an `accumulatedLocations` array while preserving insertion order. 
- Stop iterating once `accumulatedLocations.length >= requiredResultCount` where `requiredResultCount` is `(offset || 0) + limit` (or `Infinity` when `limit` is not provided), then fall back to the existing in-memory slice and return `location.id`s. 
- Added an integration test that verifies pagination and header behavior when a single location can match multiple search conditions.

### Testing
- Ran targeted linting on the modified test file with `npx eslint test/integration/find-locations.test.js`, which succeeded. 
- Ran `git diff --check` as part of validation with no new whitespace issues reported. 
- Attempted to run the integration suite with `npx jest --runInBand test/integration/find-locations.test.js`, but the test run was blocked by an unrelated test-environment issue (`fetch is not defined`) originating from the `openai` package before the suite reached the new test. 
- A repository-wide pre-commit lint step currently fails due to many existing unrelated lint errors in other files, so repository-level hooks prevented a normal pre-commit pass during local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb3aa88ab88327bd3c38f86b33d15a)