### PR TITLE
Refactor location detail endpoints to use website_data cache

### DIFF
--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -3,10 +3,10 @@ import locationSchemas from './validation/locations';
 import models from '../models';
 import { updateInstance, createInstance, destroyInstance } from '../services/data-changes';
 import {
-  getMetadataForLocation,
-  getMetadataForService,
-  getLastValidatedDateForLocation,
-} from '../services/last-updates';
+  getWebsiteDataByLocationId,
+  getWebsiteDataBySlug,
+  upsertWebsiteDataForLocation,
+} from '../services/location-website-data';
 import { eligibilityParams, documentTypes } from '../services/services';
 import geometry from '../utils/geometry';
 import { parseBoolean } from '../utils/strings';
@@ -24,124 +24,6 @@ const isLocationClosed = (occasion, eventRelatedInfos, services) => {
   eventRelatedInfos.some(eventRelatedInfo => eventRelatedInfo.event === occasion);
   return hasCOVIDEventRelatedInfo;
 };
-
-// Get location and service associations separately to reduce SQL size
-// (avoids 16KB+ queries, which would result in session pinning)
-const locationAssociations = {
-  include: [
-    {
-      model: models.Organization,
-      include: [models.Phone],
-    },
-    models.Phone,
-    models.PhysicalAddress,
-    models.AccessibilityForDisabilities,
-    models.EventRelatedInfo,
-  ],
-};
-const serviceAssociations = {
-  include: [
-    {
-      model: models.Eligibility,
-      include: [models.EligibilityParameter],
-    },
-    {
-      model: models.ServiceTaxonomySpecificAttribute,
-      include: [{ model: models.TaxonomySpecificAttribute, as: 'attribute' }],
-    },
-    {
-      model: models.Taxonomy,
-      through: { attributes: [] },
-    },
-    models.RegularSchedule,
-    models.HolidaySchedule,
-    {
-      model: models.Language,
-      through: { attributes: [] },
-    },
-    models.RequiredDocument,
-    models.DocumentsInfo,
-    models.Phone,
-    models.EventRelatedInfo,
-    models.ServiceArea,
-  ],
-};
-
-const getNeighborhoodAttributeSubquery = {
-  attributes: {
-    include: [
-      [
-        models.sequelize.literal(`(
-            SELECT neighborhood
-            FROM nyc_neighborhood_geometries
-            WHERE ST_Contains(
-              nyc_neighborhood_geometries.geometry,
-              ST_SetSRID(position,4326)
-            )
-        )`),
-        'neighborhood',
-      ],
-    ],
-  },
-};
-
-async function handleGetInfoResponse(location, locationWithServices, excludeMetadata) {
-  const {
-    PhysicalAddresses: addresses,
-    additional_info: additionalInfo,
-    ...unchangedProps
-  } = location.get({ plain: true });
-  const services = locationWithServices && locationWithServices.Services
-    ? locationWithServices.Services.map(s => s.get({ plain: true }))
-    : [];
-
-  if (!addresses || addresses.length !== 1) {
-    throw new Error('Location does not have a valid address');
-  }
-
-  const address = addresses[0];
-
-  const responseData = {
-    ...unchangedProps,
-    additionalInfo,
-    address: {
-      street: address.address_1,
-      city: address.city,
-      region: address.region,
-      state: address.state_province,
-      postalCode: address.postal_code,
-      country: address.country,
-      neighborhood: address.neighborhood,
-    },
-  };
-
-  const { EventRelatedInfos } = location;
-  // FIXME: we should not be hard-coding the COVID19 event here
-  // this is logic that needs ot be revisited in this codebase
-  const closed = isLocationClosed('COVID19', EventRelatedInfos, services);
-
-  if (excludeMetadata) {
-    const [{ lastValidatedDateForLocation }] = await getLastValidatedDateForLocation(location.id);
-    return {
-      ...responseData,
-      Services: services,
-      lastValidatedDateForLocation,
-      closed,
-    };
-  }
-  const locationMetadata = await getMetadataForLocation(location, address);
-  const servicesWithMetadata = await Promise.all(services.map(async service => ({
-    ...service,
-    metadata: await getMetadataForService(service),
-  })));
-
-  return {
-    ...responseData,
-    Services: servicesWithMetadata,
-    metadata: locationMetadata,
-    closed,
-  };
-}
 
 export default {
   find: async (req, res, next) => {
@@ -297,33 +179,7 @@ export default {
       await Joi.validate(req, locationSchemas.getInfo, { allowUnknown: true });
 
       const { locationId } = req.params;
-
-      const [location, locationWithServices] = await Promise.all([
-        models.Location.findByPk(
-          locationId,
-          {
-            include: locationAssociations.include,
-            attributes: getNeighborhoodAttributeSubquery.attributes,
-          },
-        ),
-        models.Location.findByPk(
-          locationId,
-          {
-            include: [{
-              model: models.Service,
-              through: { attributes: [] },
-              include: serviceAssociations.include,
-            }],
-            attributes: ['id'],
-          },
-        ),
-      ]);
-
-      if (!location) {
-        throw new NotFoundError('Location not found');
-      }
-
-      const getInfoResponse = await handleGetInfoResponse(location, locationWithServices, false);
+      const getInfoResponse = await getWebsiteDataByLocationId(locationId);
       res.send(getInfoResponse);
     } catch (err) {
       next(err);
@@ -333,35 +189,11 @@ export default {
   getInfoBySlug: async (req, res, next) => {
     try {
       await Joi.validate(req, locationSchemas.getInfoBySlug, { allowUnknown: true });
-
-      const locations = await models.Location.findAll({
-        where: {
-          slug: req.params.slug,
-        },
-        include: locationAssociations.include,
-        attributes: getNeighborhoodAttributeSubquery.attributes,
-      });
-
-      if (!locations.length) {
+      const getInfoResponse = await getWebsiteDataBySlug(req.params.slug);
+      if (!getInfoResponse) {
         res.status(404).send({ status: 404 });
         return;
       }
-
-      const location = locations[0];
-
-      const locationWithServices = await models.Location.findByPk(
-        location.id,
-        {
-          include: [{
-            model: models.Service,
-            through: { attributes: [] },
-            include: serviceAssociations.include,
-          }],
-          attributes: ['id'],
-        },
-      );
-
-      const getInfoResponse = await handleGetInfoResponse(location, locationWithServices, true);
       res.send(getInfoResponse);
     } catch (err) {
       next(err);
@@ -436,6 +268,8 @@ export default {
         postal_code: address.postalCode,
         country: address.country,
       }, { metadata });
+
+      await upsertWebsiteDataForLocation(createdLocation.id);
 
       res.status(201).send(createdLocation);
     } catch (err) {
@@ -527,6 +361,7 @@ export default {
       updatePromises.push(updateLocation(location, req.body, metadata));
 
       await Promise.all(updatePromises);
+      await upsertWebsiteDataForLocation(locationId);
 
       res.sendStatus(204);
     } catch (err) {
@@ -561,6 +396,7 @@ export default {
         language,
         description,
       }, { metadata });
+      await upsertWebsiteDataForLocation(locationId);
 
       res.status(201).send(createdPhone);
     } catch (err) {
@@ -582,6 +418,9 @@ export default {
       const editableFields = ['number', 'extension', 'type', 'language', 'description'];
       const { metadata, ...updateParams } = req.body;
       await updateInstance(req.user, phone, updateParams, { fields: editableFields, metadata });
+      if (phone.location_id) {
+        await upsertWebsiteDataForLocation(phone.location_id);
+      }
 
       res.sendStatus(204);
     } catch (err) {
@@ -600,7 +439,11 @@ export default {
         throw new NotFoundError('Phone not found');
       }
 
+      const { location_id: locationId } = phone;
       await destroyInstance(req.user, phone);
+      if (locationId) {
+        await upsertWebsiteDataForLocation(locationId);
+      }
       res.sendStatus(204);
     } catch (err) {
       next(err);

--- a/src/controllers/services.js
+++ b/src/controllers/services.js
@@ -1,7 +1,11 @@
 import Joi from 'joi';
 import serviceSchemas from './validation/services';
-import models, {sequelize} from '../models';
+import models, { sequelize } from '../models';
 import { createService, updateService, deleteService } from '../services/services';
+import {
+  upsertWebsiteDataForLocation,
+  upsertWebsiteDataForService,
+} from '../services/location-website-data';
 import { NotFoundError } from '../utils/errors';
 
 export default {
@@ -32,6 +36,7 @@ export default {
         req.user,
         metadata,
       );
+      await upsertWebsiteDataForLocation(locationId);
       res.status(201).send(createdService);
     } catch (err) {
       next(err);
@@ -64,6 +69,7 @@ export default {
       }
 
       await updateService(service, { ...otherProps, taxonomy }, req.user, metadata);
+      await upsertWebsiteDataForService(serviceId);
       res.sendStatus(204);
     } catch (err) {
       next(err);
@@ -74,8 +80,18 @@ export default {
     try {
       await Joi.validate(req, serviceSchemas.delete, { allowUnknown: true });
       const { serviceId } = req.params;
-
+      const service = await models.Service.findByPk(serviceId, {
+        include: [{
+          model: models.Location,
+          through: { attributes: [] },
+          attributes: ['id'],
+        }],
+      });
+      const relatedLocationIds = service ? service.Locations.map(location => location.id) : [];
       await deleteService(serviceId, req.user);
+      const websiteDataUpdates = relatedLocationIds
+        .map(locationId => upsertWebsiteDataForLocation(locationId));
+      await Promise.all(websiteDataUpdates);
 
       res.sendStatus(204);
     } catch (err) {
@@ -85,8 +101,7 @@ export default {
 
   getCount: async (req, res, next) => {
     try {
-      const [servicesCount] = await sequelize.query(
-        `
+      const serviceCountQuery = `
           select count(*)
           from locations
                  join organizations o on o.id = locations.organization_id
@@ -97,8 +112,8 @@ export default {
             from holiday_schedules as hs
                    join service_at_locations as sal on sal.service_id = hs.service_id
             where sal.location_id = locations.id
-          )    `,
-      );
+          )    `;
+      const [servicesCount] = await sequelize.query(serviceCountQuery);
       res.send(servicesCount[0]).status(200);
     } catch (err) {
       next(err);

--- a/src/models/website-data.js
+++ b/src/models/website-data.js
@@ -1,0 +1,22 @@
+module.exports = (sequelize, DataTypes) => {
+  const WebsiteData = sequelize.define('WebsiteData', {
+    slug: DataTypes.TEXT,
+    data: DataTypes.TEXT,
+    updated_at: DataTypes.DATE,
+    location_id: DataTypes.UUID,
+  }, {
+    tableName: 'website_data',
+    timestamps: false,
+    underscored: true,
+    underscoredAll: true,
+  });
+
+  WebsiteData.associate = (models) => {
+    WebsiteData.belongsTo(models.Location, {
+      foreignKey: 'location_id',
+      targetKey: 'id',
+    });
+  };
+
+  return WebsiteData;
+};

--- a/src/services/location-website-data.js
+++ b/src/services/location-website-data.js
@@ -1,0 +1,246 @@
+import models from '../models';
+import {
+  getMetadataForLocation,
+  getMetadataForService,
+  getLastValidatedDateForLocation,
+} from './last-updates';
+import { NotFoundError } from '../utils/errors';
+
+const isLocationClosed = (occasion, eventRelatedInfos, services) => {
+  if (!occasion) {
+    return false;
+  }
+  const hasCOVIDEventRelatedInfo = eventRelatedInfos
+    && eventRelatedInfos.some(eventRelatedInfo => eventRelatedInfo.event === occasion);
+  return hasCOVIDEventRelatedInfo;
+};
+
+const locationAssociations = {
+  include: [
+    {
+      model: models.Organization,
+      include: [models.Phone],
+    },
+    models.Phone,
+    models.PhysicalAddress,
+    models.AccessibilityForDisabilities,
+    models.EventRelatedInfo,
+  ],
+};
+
+const serviceAssociations = {
+  include: [
+    {
+      model: models.Eligibility,
+      include: [models.EligibilityParameter],
+    },
+    {
+      model: models.ServiceTaxonomySpecificAttribute,
+      include: [{ model: models.TaxonomySpecificAttribute, as: 'attribute' }],
+    },
+    {
+      model: models.Taxonomy,
+      through: { attributes: [] },
+    },
+    models.RegularSchedule,
+    models.HolidaySchedule,
+    {
+      model: models.Language,
+      through: { attributes: [] },
+    },
+    models.RequiredDocument,
+    models.DocumentsInfo,
+    models.Phone,
+    models.EventRelatedInfo,
+    models.ServiceArea,
+  ],
+};
+
+const getNeighborhoodAttributeSubquery = {
+  attributes: {
+    include: [
+      [
+        models.sequelize.literal(`(
+            SELECT neighborhood
+            FROM nyc_neighborhood_geometries
+            WHERE ST_Contains(
+              nyc_neighborhood_geometries.geometry,
+              ST_SetSRID(position,4326)
+            )
+        )`),
+        'neighborhood',
+      ],
+    ],
+  },
+};
+
+async function buildLocationResponse(location, locationWithServices, excludeMetadata) {
+  const {
+    PhysicalAddresses: addresses,
+    additional_info: additionalInfo,
+    ...unchangedProps
+  } = location.get({ plain: true });
+
+  const services = locationWithServices && locationWithServices.Services
+    ? locationWithServices.Services.map(s => s.get({ plain: true }))
+    : [];
+
+  if (!addresses || addresses.length !== 1) {
+    throw new Error('Location does not have a valid address');
+  }
+
+  const address = addresses[0];
+
+  const responseData = {
+    ...unchangedProps,
+    additionalInfo,
+    address: {
+      street: address.address_1,
+      city: address.city,
+      region: address.region,
+      state: address.state_province,
+      postalCode: address.postal_code,
+      country: address.country,
+      neighborhood: address.neighborhood,
+    },
+  };
+
+  const { EventRelatedInfos } = location;
+  const closed = isLocationClosed('COVID19', EventRelatedInfos, services);
+
+  if (excludeMetadata) {
+    const [{ lastValidatedDateForLocation }] = await getLastValidatedDateForLocation(location.id);
+    return {
+      ...responseData,
+      Services: services,
+      lastValidatedDateForLocation,
+      closed,
+    };
+  }
+
+  const locationMetadata = await getMetadataForLocation(location, address);
+  const servicesWithMetadata = await Promise.all(services.map(async service => ({
+    ...service,
+    metadata: await getMetadataForService(service),
+  })));
+
+  return {
+    ...responseData,
+    Services: servicesWithMetadata,
+    metadata: locationMetadata,
+    closed,
+  };
+}
+
+async function buildLocationGetInfoResponse(locationId) {
+  const [location, locationWithServices] = await Promise.all([
+    models.Location.findByPk(
+      locationId,
+      {
+        include: locationAssociations.include,
+        attributes: getNeighborhoodAttributeSubquery.attributes,
+      },
+    ),
+    models.Location.findByPk(
+      locationId,
+      {
+        include: [{
+          model: models.Service,
+          through: { attributes: [] },
+          include: serviceAssociations.include,
+        }],
+        attributes: ['id'],
+      },
+    ),
+  ]);
+
+  if (!location) {
+    throw new NotFoundError('Location not found');
+  }
+
+  return buildLocationResponse(location, locationWithServices, false);
+}
+
+function parseWebsiteDataRow(websiteData) {
+  if (!websiteData) {
+    return null;
+  }
+
+  return JSON.parse(websiteData.data);
+}
+
+export async function upsertWebsiteDataForLocation(locationId) {
+  const getInfoResponse = await buildLocationGetInfoResponse(locationId);
+  const now = new Date();
+
+  const existingWebsiteData = await models.WebsiteData.findOne({
+    where: { location_id: locationId },
+  });
+
+  const updateData = {
+    slug: getInfoResponse.slug,
+    data: JSON.stringify(getInfoResponse),
+    updated_at: now,
+    location_id: locationId,
+  };
+
+  if (existingWebsiteData) {
+    await existingWebsiteData.update(updateData);
+  } else {
+    await models.WebsiteData.create(updateData);
+  }
+
+  return getInfoResponse;
+}
+
+export async function getWebsiteDataByLocationId(locationId) {
+  const websiteData = await models.WebsiteData.findOne({
+    where: { location_id: locationId },
+  });
+
+  if (websiteData) {
+    return parseWebsiteDataRow(websiteData);
+  }
+
+  return upsertWebsiteDataForLocation(locationId);
+}
+
+export async function getWebsiteDataBySlug(slug) {
+  const slugLeafExpression = [
+    'split_part(slug, \'/\',',
+    'array_length(string_to_array(slug, \'/\'), 1))',
+  ].join(' ');
+  const websiteData = await models.WebsiteData.findOne({
+    where: models.sequelize.where(
+      models.sequelize.literal(slugLeafExpression),
+      slug,
+    ),
+  });
+
+  if (websiteData) {
+    return parseWebsiteDataRow(websiteData);
+  }
+
+  const location = await models.Location.findOne({ where: { slug } });
+  if (!location) {
+    return null;
+  }
+
+  return upsertWebsiteDataForLocation(location.id);
+}
+
+export async function upsertWebsiteDataForService(serviceId) {
+  const service = await models.Service.findByPk(serviceId, {
+    include: [{
+      model: models.Location,
+      through: { attributes: [] },
+      attributes: ['id'],
+    }],
+  });
+
+  if (!service || !service.Locations) {
+    return;
+  }
+
+  await Promise.all(service.Locations.map(location => upsertWebsiteDataForLocation(location.id)));
+}


### PR DESCRIPTION
### Motivation
- Reduce heavy multi-table joins on the location detail endpoints by serving precomputed JSON stored in the existing `website_data` table.
- Ensure write operations update a cached JSON representation so `GET /locations/:locationId` and `GET /locations-by-slug/:slug` can be fast and avoid expensive queries.

### Description
- Added a `WebsiteData` Sequelize model at `src/models/website-data.js` to represent the existing `website_data` table.
- Added `src/services/location-website-data.js` which centralizes building the full location detail payload, parsing/storing JSON into `website_data`, `getWebsiteDataByLocationId`, `getWebsiteDataBySlug`, `upsertWebsiteDataForLocation`, and `upsertWebsiteDataForService` (which refreshes all locations affected by a service change).
- Updated `GET /locations/:locationId` and `GET /locations-by-slug/:slug` (in `src/controllers/locations.js`) to use `getWebsiteDataByLocationId` and `getWebsiteDataBySlug` respectively, with lazy backfill when cache rows are missing.
- Updated write endpoints to refresh cache after successful mutations: `locations.create`/`update`, `locations.addPhone`/`updatePhone`/`deletePhone`, and `services.create`/`update`/`delete` now call the appropriate `upsertWebsiteData*` functions, and slug lookup in cache supports matching the final slash-delimited segment.

### Testing
- Ran `npx eslint src/controllers/locations.js src/controllers/services.js src/services/location-website-data.js src/models/website-data.js` and the lint check for those modified files completed successfully.
- Ran the test suite with `npm test -- --runInBand` and it failed in this environment due to the Node test runtime missing the `fetch` shim required by the installed `openai` package (not related to the location cache changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8563221e48327a9f8c899050740ce)