### PR TITLE
Add location deletion scheduling

### DIFF
--- a/sequelize/migrations/20260310194000-create-location-deletion-schedules.js
+++ b/sequelize/migrations/20260310194000-create-location-deletion-schedules.js
@@ -1,0 +1,57 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('location_deletion_schedules', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        allowNull: false,
+      },
+      location_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        unique: true,
+        references: {
+          model: {
+            tableName: 'locations',
+          },
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      note: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      requested_by: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      scheduled_for_permanent_deletion_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      deleted_service_count: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      },
+      was_hidden_from_search: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('location_deletion_schedules');
+  },
+};

--- a/sequelize/migrations/20260310213000-add-service-snapshots-to-location-deletion-schedules.js
+++ b/sequelize/migrations/20260310213000-add-service-snapshots-to-location-deletion-schedules.js
@@ -1,0 +1,13 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('location_deletion_schedules', 'service_snapshots', {
+      type: Sequelize.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('location_deletion_schedules', 'service_snapshots');
+  },
+};

--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -7,6 +7,13 @@ import {
   getMetadataForService,
   getLastValidatedDateForLocation,
 } from '../services/last-updates';
+import {
+  listScheduledLocationDeletions,
+  restoreLocationDeletion,
+  scheduleLocationDeletion,
+  serializeLocationDeletionSchedule,
+} from '../services/location-deletions';
+import slackNotifier from '../services/slack-notifier';
 import { eligibilityParams, documentTypes } from '../services/services';
 import geometry from '../utils/geometry';
 import { parseBoolean } from '../utils/strings';
@@ -383,6 +390,58 @@ export default {
       } else {
         res.status(404).send({ error: 'Location slug not found' });
       }
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  getDeletionSchedules: async (req, res, next) => {
+    try {
+      await Joi.validate(req, locationSchemas.getDeletionSchedules, { allowUnknown: true });
+
+      const schedules = await listScheduledLocationDeletions();
+      res.send(schedules.map(serializeLocationDeletionSchedule));
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  scheduleDeletion: async (req, res, next) => {
+    try {
+      await Joi.validate(req, locationSchemas.scheduleDeletion, { allowUnknown: true });
+
+      const { locationId } = req.params;
+      const { note } = req.body;
+
+      const schedule = await scheduleLocationDeletion(locationId, note, req.user);
+
+      try {
+        await slackNotifier.notifyLocationDeletionScheduled({
+          location: schedule.Location,
+          note: schedule.note,
+          requestedBy: schedule.requested_by,
+          deletedServiceCount: schedule.deleted_service_count,
+          scheduledForPermanentDeletionAt: schedule.scheduled_for_permanent_deletion_at,
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Error notifying Slack of scheduled location deletion', err);
+      }
+
+      res.status(201).send(serializeLocationDeletionSchedule(schedule));
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  restoreDeletion: async (req, res, next) => {
+    try {
+      await Joi.validate(req, locationSchemas.restoreDeletion, { allowUnknown: true });
+
+      const { locationId } = req.params;
+      await restoreLocationDeletion(locationId, req.user);
+
+      res.sendStatus(204);
     } catch (err) {
       next(err);
     }

--- a/src/controllers/validation/locations.js
+++ b/src/controllers/validation/locations.js
@@ -60,6 +60,10 @@ export default {
     }).required(),
   },
 
+  getDeletionSchedules: {
+    query: Joi.object().keys({}).required(),
+  },
+
   create: {
     body: Joi.object().keys({
       name: Joi.string(),
@@ -104,6 +108,21 @@ export default {
         information: Joi.string().required().allow(null),
       }),
       metadata: updateMetadataSchema,
+    }).required(),
+  },
+
+  scheduleDeletion: {
+    params: Joi.object().keys({
+      locationId: Joi.string().guid().required(),
+    }).required(),
+    body: Joi.object().keys({
+      note: Joi.string().trim().min(1).required(),
+    }).required(),
+  },
+
+  restoreDeletion: {
+    params: Joi.object().keys({
+      locationId: Joi.string().guid().required(),
     }).required(),
   },
 

--- a/src/models/location-deletion-schedule.js
+++ b/src/models/location-deletion-schedule.js
@@ -1,0 +1,46 @@
+module.exports = (sequelize, DataTypes) => {
+  const LocationDeletionSchedule = sequelize.define('LocationDeletionSchedule', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    note: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    requested_by: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    scheduled_for_permanent_deletion_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    deleted_service_count: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    },
+    was_hidden_from_search: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+  }, {
+    underscored: true,
+    underscoredAll: true,
+  });
+
+  LocationDeletionSchedule.associate = (models) => {
+    LocationDeletionSchedule.belongsTo(models.Location, {
+      foreignKey: {
+        name: 'location_id',
+        allowNull: false,
+      },
+      onDelete: 'CASCADE',
+    });
+  };
+
+  return LocationDeletionSchedule;
+};

--- a/src/models/location-deletion-schedule.js
+++ b/src/models/location-deletion-schedule.js
@@ -22,6 +22,11 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       defaultValue: 0,
     },
+    service_snapshots: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    },
     was_hidden_from_search: {
       type: DataTypes.BOOLEAN,
       allowNull: false,

--- a/src/models/location.js
+++ b/src/models/location.js
@@ -70,6 +70,7 @@ module.exports = (sequelize, DataTypes, Op) => {
     Location.hasMany(models.Comment, { foreignKey: 'location_id' });
     Location.hasMany(models.ErrorReport, { foreignKey: 'location_id' });
     Location.hasMany(models.LocationSlugRedirect, { foreignKey: 'location_id' });
+    Location.hasOne(models.LocationDeletionSchedule, { foreignKey: 'location_id' });
 
     // Can't just set defaultScope on the initial model definition:
     // https://github.com/sequelize/sequelize/issues/6245.

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,10 +25,13 @@ export default (app) => {
   app.get('/locations', locations.find);
 
   app.post('/locations/suggestions', locations.suggestNew);
+  app.get('/locations/deletion-schedules', getUser, locations.getDeletionSchedules);
   app.get('/locations-by-slug/:slug', locations.getInfoBySlug);
   app.get('/location-slug-redirects/:slug', locations.getRedirectBySlug);
 
   app.get('/locations/:locationId', locations.getInfo);
+  app.post('/locations/:locationId/deletion-schedule', getUser, locations.scheduleDeletion);
+  app.delete('/locations/:locationId/deletion-schedule', getUser, locations.restoreDeletion);
   app.post('/locations', getUser, dataEntryAuth, locations.create);
   app.patch('/locations/:locationId', getUser, dataEntryAuth, locations.update);
 
@@ -63,7 +66,6 @@ export default (app) => {
   app.get('/comment-highlights', commentHighlights.getHighlights);
   app.post('/generate-highlights', commentHighlights.generateHighlights);
   app.post('/regenerate-highlights', commentHighlights.regenerateHighlights);
-
 
   app.get('/errorreports', getUser, errorReports.get);
   app.post('/errorreports', errorReports.create);

--- a/src/services/location-deletions.js
+++ b/src/services/location-deletions.js
@@ -6,6 +6,32 @@ import { NotFoundError, ValidationError } from '../utils/errors';
 const { sequelize } = models;
 const SHARED_SERVICE_DELETION_ERROR =
   'Cannot schedule deletion for a location with services shared across multiple locations';
+const snapshotServiceIncludes = [
+  {
+    model: models.Location,
+    attributes: ['id'],
+  },
+  models.Taxonomy,
+  models.Language,
+  models.RequiredDocument,
+  models.DocumentsInfo,
+  {
+    model: models.Eligibility,
+    include: [models.EligibilityParameter],
+  },
+  {
+    model: models.ServiceTaxonomySpecificAttribute,
+    include: [{
+      model: models.TaxonomySpecificAttribute,
+      as: 'attribute',
+    }],
+  },
+  models.RegularSchedule,
+  models.HolidaySchedule,
+  models.Phone,
+  models.EventRelatedInfo,
+  models.ServiceArea,
+];
 
 const addOneMonth = (date) => {
   const nextDate = new Date(date);
@@ -44,10 +70,7 @@ const getLocationForDeletion = (locationId, transaction) => models.Location.find
     models.Organization,
     {
       model: models.Service,
-      include: [{
-        model: models.Location,
-        attributes: ['id'],
-      }],
+      include: snapshotServiceIncludes,
     },
   ],
   transaction,
@@ -72,6 +95,239 @@ const assertServicesAreExclusiveToLocation = (location) => {
   }
 };
 
+const createServiceSnapshot = (service, locationId) => {
+  const plainService = service.get({ plain: true });
+  const locationLink =
+    plainService.Locations.find(serviceLocation => serviceLocation.id === locationId);
+
+  return {
+    service: {
+      name: plainService.name,
+      description: plainService.description,
+      url: plainService.url,
+      email: plainService.email,
+      interpretation_services: plainService.interpretation_services,
+      fees: plainService.fees,
+      additional_info: plainService.additional_info,
+    },
+    serviceAtLocation: locationLink && locationLink.ServiceAtLocation
+      ? {
+        description: locationLink.ServiceAtLocation.description,
+      }
+      : null,
+    taxonomies: plainService.Taxonomies.map(({ id }) => ({ taxonomy_id: id })),
+    languages: plainService.Languages.map(({ id }) => ({ language_id: id })),
+    documentsInfo: plainService.DocumentsInfo
+      ? {
+        recertification_time: plainService.DocumentsInfo.recertification_time,
+        grace_period: plainService.DocumentsInfo.grace_period,
+        additional_info: plainService.DocumentsInfo.additional_info,
+      }
+      : null,
+    requiredDocuments: plainService.RequiredDocuments.map(({ document }) => ({ document })),
+    eligibilities: plainService.Eligibilities.map(eligibility => ({
+      parameter_id: eligibility.parameter_id,
+      description: eligibility.description,
+      eligible_values: eligibility.eligible_values,
+    })),
+    taxonomySpecificAttributes: plainService.ServiceTaxonomySpecificAttributes.map(attribute => ({
+      attribute_id: attribute.attribute_id,
+      values: attribute.values,
+    })),
+    regularSchedules: plainService.RegularSchedules.map(schedule => ({
+      weekday: schedule.weekday,
+      opens_at: schedule.opens_at,
+      closes_at: schedule.closes_at,
+    })),
+    holidaySchedules: plainService.HolidaySchedules.map(schedule => ({
+      closed: schedule.closed,
+      opens_at: schedule.opens_at,
+      closes_at: schedule.closes_at,
+      start_date: schedule.start_date,
+      end_date: schedule.end_date,
+      weekday: schedule.weekday,
+      occasion: schedule.occasion,
+    })),
+    phones: plainService.Phones.map(phone => ({
+      number: phone.number,
+      extension: phone.extension,
+      type: phone.type,
+      language: phone.language,
+      description: phone.description,
+    })),
+    eventRelatedInfos: plainService.EventRelatedInfos.map(info => ({
+      event: info.event,
+      information: info.information,
+    })),
+    serviceAreas: plainService.ServiceAreas.map(area => ({
+      postal_codes: area.postal_codes,
+      description: area.description,
+    })),
+  };
+};
+
+const restoreServiceSnapshot = async (location, serviceSnapshot, user, transaction) => {
+  const restoredService = await createInstance(
+    user,
+    models.Service.create.bind(models.Service),
+    {
+      ...serviceSnapshot.service,
+      organization_id: location.organization_id,
+    },
+    { transaction },
+  );
+
+  await createInstance(
+    user,
+    models.ServiceAtLocation.create.bind(models.ServiceAtLocation),
+    {
+      service_id: restoredService.id,
+      location_id: location.id,
+      description: serviceSnapshot.serviceAtLocation &&
+        serviceSnapshot.serviceAtLocation.description,
+    },
+    { transaction },
+  );
+
+  await Promise.all(serviceSnapshot.taxonomies.map(({ taxonomy_id: taxonomyId }) =>
+    createInstance(
+      user,
+      models.ServiceTaxonomy.create.bind(models.ServiceTaxonomy),
+      {
+        service_id: restoredService.id,
+        taxonomy_id: taxonomyId,
+      },
+      { transaction },
+    )));
+
+  await Promise.all(serviceSnapshot.languages.map(({ language_id: languageId }) =>
+    createInstance(
+      user,
+      models.ServiceLanguages.create.bind(models.ServiceLanguages),
+      {
+        service_id: restoredService.id,
+        language_id: languageId,
+      },
+      { transaction },
+    )));
+
+  await createInstance(
+    user,
+    models.DocumentsInfo.create.bind(models.DocumentsInfo),
+    {
+      service_id: restoredService.id,
+      ...(serviceSnapshot.documentsInfo || {}),
+    },
+    { transaction },
+  );
+
+  await Promise.all(serviceSnapshot.requiredDocuments.map(requiredDocument =>
+    createInstance(
+      user,
+      models.RequiredDocument.create.bind(models.RequiredDocument),
+      {
+        service_id: restoredService.id,
+        document: requiredDocument.document,
+      },
+      { transaction },
+    )));
+
+  await Promise.all(serviceSnapshot.eligibilities.map(eligibility =>
+    createInstance(
+      user,
+      models.Eligibility.create.bind(models.Eligibility),
+      {
+        service_id: restoredService.id,
+        parameter_id: eligibility.parameter_id,
+        description: eligibility.description,
+        eligible_values: eligibility.eligible_values,
+      },
+      { transaction },
+    )));
+
+  await Promise.all(serviceSnapshot.taxonomySpecificAttributes.map(attribute =>
+    createInstance(
+      user,
+      models.ServiceTaxonomySpecificAttribute.create
+        .bind(models.ServiceTaxonomySpecificAttribute),
+      {
+        service_id: restoredService.id,
+        attribute_id: attribute.attribute_id,
+        values: attribute.values,
+      },
+      { transaction },
+    )));
+
+  await Promise.all(serviceSnapshot.regularSchedules.map(schedule =>
+    createInstance(
+      user,
+      models.RegularSchedule.create.bind(models.RegularSchedule),
+      {
+        service_id: restoredService.id,
+        weekday: schedule.weekday,
+        opens_at: schedule.opens_at,
+        closes_at: schedule.closes_at,
+      },
+      { transaction },
+    )));
+
+  await Promise.all(serviceSnapshot.holidaySchedules.map(schedule =>
+    createInstance(
+      user,
+      models.HolidaySchedule.create.bind(models.HolidaySchedule),
+      {
+        service_id: restoredService.id,
+        closed: schedule.closed,
+        opens_at: schedule.opens_at,
+        closes_at: schedule.closes_at,
+        start_date: schedule.start_date,
+        end_date: schedule.end_date,
+        weekday: schedule.weekday,
+        occasion: schedule.occasion,
+      },
+      { transaction },
+    )));
+
+  await Promise.all(serviceSnapshot.phones.map(phone =>
+    createInstance(
+      user,
+      models.Phone.create.bind(models.Phone),
+      {
+        service_id: restoredService.id,
+        number: phone.number,
+        extension: phone.extension,
+        type: phone.type,
+        language: phone.language,
+        description: phone.description,
+      },
+      { transaction },
+    )));
+
+  await Promise.all(serviceSnapshot.eventRelatedInfos.map(info =>
+    createInstance(
+      user,
+      models.EventRelatedInfo.create.bind(models.EventRelatedInfo),
+      {
+        service_id: restoredService.id,
+        event: info.event,
+        information: info.information,
+      },
+      { transaction },
+    )));
+
+  await Promise.all(serviceSnapshot.serviceAreas.map(area =>
+    createInstance(
+      user,
+      models.ServiceArea.create.bind(models.ServiceArea),
+      {
+        service_id: restoredService.id,
+        postal_codes: area.postal_codes,
+        description: area.description,
+      },
+      { transaction },
+    )));
+};
+
 export const scheduleLocationDeletion = (locationId, note, user) =>
   sequelize.transaction(async (transaction) => {
     const location = await getLocationForDeletion(locationId, transaction);
@@ -88,6 +344,8 @@ export const scheduleLocationDeletion = (locationId, note, user) =>
 
     const deletedServiceCount = location.Services.length;
     const wasHiddenFromSearch = Boolean(location.hidden_from_search);
+    const serviceSnapshots = location.Services
+      .map(service => createServiceSnapshot(service, location.id));
 
     await Promise.all(location.Services.map(service =>
       deleteService(service.id, user, { transaction })));
@@ -111,6 +369,7 @@ export const scheduleLocationDeletion = (locationId, note, user) =>
         requested_by: user,
         scheduled_for_permanent_deletion_at: addOneMonth(new Date()),
         deleted_service_count: deletedServiceCount,
+        service_snapshots: serviceSnapshots,
         was_hidden_from_search: wasHiddenFromSearch,
       },
       { transaction },
@@ -133,6 +392,9 @@ export const restoreLocationDeletion = (locationId, user) =>
     if (!schedule) {
       throw new NotFoundError('Location is not scheduled for deletion');
     }
+
+    await Promise.all((schedule.service_snapshots || []).map(serviceSnapshot =>
+      restoreServiceSnapshot(schedule.Location, serviceSnapshot, user, transaction)));
 
     await updateInstance(
       user,

--- a/src/services/location-deletions.js
+++ b/src/services/location-deletions.js
@@ -1,0 +1,155 @@
+import models from '../models';
+import { createInstance, destroyInstance, updateInstance } from './data-changes';
+import { deleteService } from './services';
+import { NotFoundError, ValidationError } from '../utils/errors';
+
+const { sequelize } = models;
+const SHARED_SERVICE_DELETION_ERROR =
+  'Cannot schedule deletion for a location with services shared across multiple locations';
+
+const addOneMonth = (date) => {
+  const nextDate = new Date(date);
+  nextDate.setMonth(nextDate.getMonth() + 1);
+  return nextDate;
+};
+
+export const serializeLocationDeletionSchedule = (scheduleInstance) => {
+  const schedule = scheduleInstance.get
+    ? scheduleInstance.get({ plain: true })
+    : scheduleInstance;
+  const location = schedule.Location || {};
+  const organization = location.Organization || {};
+
+  return {
+    id: schedule.id,
+    note: schedule.note,
+    requestedBy: schedule.requested_by,
+    deletedServiceCount: schedule.deleted_service_count,
+    scheduledForPermanentDeletionAt: schedule.scheduled_for_permanent_deletion_at,
+    createdAt: schedule.created_at,
+    location: {
+      id: location.id,
+      name: location.name,
+      slug: location.slug,
+    },
+    organization: {
+      id: organization.id,
+      name: organization.name,
+    },
+  };
+};
+
+const getLocationForDeletion = (locationId, transaction) => models.Location.findByPk(locationId, {
+  include: [
+    models.Organization,
+    {
+      model: models.Service,
+      include: [{
+        model: models.Location,
+        attributes: ['id'],
+      }],
+    },
+  ],
+  transaction,
+});
+
+const getScheduleWithLocation = (locationId, transaction) =>
+  models.LocationDeletionSchedule.findOne({
+    where: { location_id: locationId },
+    include: [{
+      model: models.Location,
+      include: [models.Organization],
+    }],
+    transaction,
+  });
+
+const assertServicesAreExclusiveToLocation = (location) => {
+  const sharedServices = location.Services.filter(service =>
+    service.Locations.some(serviceLocation => serviceLocation.id !== location.id));
+
+  if (sharedServices.length) {
+    throw new ValidationError(SHARED_SERVICE_DELETION_ERROR);
+  }
+};
+
+export const scheduleLocationDeletion = (locationId, note, user) =>
+  sequelize.transaction(async (transaction) => {
+    const location = await getLocationForDeletion(locationId, transaction);
+    if (!location) {
+      throw new NotFoundError('Location not found');
+    }
+
+    const existingSchedule = await getScheduleWithLocation(locationId, transaction);
+    if (existingSchedule) {
+      throw new ValidationError('Location is already scheduled for deletion');
+    }
+
+    assertServicesAreExclusiveToLocation(location);
+
+    const deletedServiceCount = location.Services.length;
+    const wasHiddenFromSearch = Boolean(location.hidden_from_search);
+
+    await Promise.all(location.Services.map(service =>
+      deleteService(service.id, user, { transaction })));
+
+    await updateInstance(
+      user,
+      location,
+      { hidden_from_search: true },
+      {
+        fields: ['hidden_from_search'],
+        transaction,
+      },
+    );
+
+    await createInstance(
+      user,
+      models.LocationDeletionSchedule.create.bind(models.LocationDeletionSchedule),
+      {
+        location_id: location.id,
+        note,
+        requested_by: user,
+        scheduled_for_permanent_deletion_at: addOneMonth(new Date()),
+        deleted_service_count: deletedServiceCount,
+        was_hidden_from_search: wasHiddenFromSearch,
+      },
+      { transaction },
+    );
+
+    return getScheduleWithLocation(locationId, transaction);
+  });
+
+export const listScheduledLocationDeletions = () => models.LocationDeletionSchedule.findAll({
+  include: [{
+    model: models.Location,
+    include: [models.Organization],
+  }],
+  order: [['scheduled_for_permanent_deletion_at', 'ASC']],
+});
+
+export const restoreLocationDeletion = (locationId, user) =>
+  sequelize.transaction(async (transaction) => {
+    const schedule = await getScheduleWithLocation(locationId, transaction);
+    if (!schedule) {
+      throw new NotFoundError('Location is not scheduled for deletion');
+    }
+
+    await updateInstance(
+      user,
+      schedule.Location,
+      { hidden_from_search: schedule.was_hidden_from_search },
+      {
+        fields: ['hidden_from_search'],
+        transaction,
+      },
+    );
+
+    await destroyInstance(user, schedule, { transaction });
+  });
+
+export default {
+  scheduleLocationDeletion,
+  listScheduledLocationDeletions,
+  restoreLocationDeletion,
+  serializeLocationDeletionSchedule,
+};

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -266,15 +266,14 @@ export const updateService = (
   if (area) {
     updatePromises.push(updateServiceAreas(service, area, { t, user, metadata }));
   }
- 
-  if(whoDoesItServe) {
 
+  if (whoDoesItServe) {
     updatePromises.push(updateEligibilityParam(
       service,
       'age',
       {
         eligible_values: whoDoesItServe,
-        description: ''
+        description: '',
       },
       { t, user, metadata },
     ));
@@ -366,42 +365,56 @@ export const createService = async (
   return createdService;
 });
 
-export const deleteService = (serviceId, user) => sequelize.transaction(async (t) => {
-  const service = await models.Service.findByPk(serviceId, { include: [models.Location] });
-  if (!service) return;
+const startTransactionOrUseExisting = (options, callback) => {
+  if (options && options.transaction) {
+    return callback(options.transaction);
+  }
 
-  const destroyAssociation = model =>
-    model.destroy({ where: { service_id: serviceId }, transaction: t });
-  await Promise.all([
-    destroyAssociation(models.DocumentsInfo),
-    destroyAssociation(models.Eligibility),
-    destroyAssociation(models.HolidaySchedule),
-    destroyAssociation(models.RegularSchedule),
-    destroyAssociation(models.RequiredDocument),
-    destroyAssociation(models.ServiceArea),
-    destroyAssociation(models.Phone),
-    destroyAssociation(models.ServiceTaxonomySpecificAttribute),
-  ]);
+  return sequelize.transaction(callback);
+};
 
-  const recordLocationOfDeletedService = async () => {
-    const location = service.Locations[0];
-    await models.Metadata.create({
-      resource_table: models.ServiceAtLocation.tableName,
-      resource_id: location.ServiceAtLocation.id,
-      last_action_date: new Date(),
-      last_action_type: models.Metadata.actionTypes.delete,
-      field_name: 'location_id',
-      previous_value: location.id,
-      updated_by: user,
-      source: `${service.id} service deletion`,
-    }, { transaction: t });
-  };
+export const deleteService = (serviceId, user, options = {}) => startTransactionOrUseExisting(
+  options,
+  async (t) => {
+    const service = await models.Service.findByPk(serviceId, {
+      include: [models.Location],
+      transaction: t,
+    });
+    if (!service) return;
 
-  await Promise.all([
-    destroyInstance(user, service, { transaction: t }),
-    recordLocationOfDeletedService(),
-  ]);
-});
+    const destroyAssociation = model =>
+      model.destroy({ where: { service_id: serviceId }, transaction: t });
+    await Promise.all([
+      destroyAssociation(models.DocumentsInfo),
+      destroyAssociation(models.Eligibility),
+      destroyAssociation(models.HolidaySchedule),
+      destroyAssociation(models.RegularSchedule),
+      destroyAssociation(models.RequiredDocument),
+      destroyAssociation(models.ServiceArea),
+      destroyAssociation(models.Phone),
+      destroyAssociation(models.ServiceTaxonomySpecificAttribute),
+    ]);
+
+    const recordLocationOfDeletedService = async () => {
+      const location = service.Locations[0];
+      await models.Metadata.create({
+        resource_table: models.ServiceAtLocation.tableName,
+        resource_id: location.ServiceAtLocation.id,
+        last_action_date: new Date(),
+        last_action_type: models.Metadata.actionTypes.delete,
+        field_name: 'location_id',
+        previous_value: location.id,
+        updated_by: user,
+        source: `${service.id} service deletion`,
+      }, { transaction: t });
+    };
+
+    await Promise.all([
+      destroyInstance(user, service, { transaction: t }),
+      recordLocationOfDeletedService(),
+    ]);
+  },
+);
 
 export default {
   updateService,

--- a/src/services/slack-notifier.js
+++ b/src/services/slack-notifier.js
@@ -44,6 +44,35 @@ const notifyErrorReport = async ({
   return axios.post(config.slackWebhookUrl, { text });
 };
 
+const notifyLocationDeletionScheduled = async ({
+  location,
+  note,
+  requestedBy,
+  deletedServiceCount,
+  scheduledForPermanentDeletionAt,
+}) => {
+  const { slackWebhookUrl } = config;
+
+  if (!slackWebhookUrl) {
+    return Promise.resolve();
+  }
+
+  const organizationName = location.Organization
+    ? location.Organization.name
+    : 'Unknown organization';
+  const locationName = location.name || 'Unknown location';
+  const scheduledDate = new Date(scheduledForPermanentDeletionAt).toISOString();
+  const text = [
+    `Location scheduled for deletion: *${organizationName}* / *${locationName}*`,
+    `Requested by: ${requestedBy}`,
+    `Deleted services immediately: ${deletedServiceCount}`,
+    `Scheduled for permanent deletion: ${scheduledDate}`,
+    `Reason: "_${note}_"`,
+  ].join('\n');
+
+  return axios.post(config.slackWebhookUrl, { text });
+};
+
 export default {
   notifyNewComment: async commentParams => notifyComment('New comment', commentParams),
 
@@ -53,4 +82,5 @@ export default {
   }) => notifyComment(`New reply to comment "${originalComment.content}"`, commentParams),
 
   notifyErrorReport,
+  notifyLocationDeletionScheduled,
 };

--- a/test/integration/location-deletion-schedules.test.js
+++ b/test/integration/location-deletion-schedules.test.js
@@ -1,0 +1,215 @@
+/**
+ * @jest-environment node
+ */
+
+import request from 'supertest';
+import app from '../../src/app';
+import models from '../../src/models';
+
+describe('location deletion schedules', () => {
+  const sharedServiceError =
+    'Cannot schedule deletion for a location with services shared across multiple locations';
+
+  const clearData = async () => {
+    await Promise.all([
+      models.LocationDeletionSchedule.destroy({ where: {} }),
+      models.LocationSlugRedirect.destroy({ where: {} }),
+      models.CommentLike.destroy({ where: {} }),
+      models.Comment.destroy({ where: {} }),
+      models.ErrorReport.destroy({ where: {} }),
+      models.Phone.destroy({ where: {} }),
+      models.EventRelatedInfo.destroy({ where: {} }),
+      models.AccessibilityForDisabilities.destroy({ where: {} }),
+      models.RegularSchedule.destroy({ where: {} }),
+      models.HolidaySchedule.destroy({ where: {} }),
+      models.ServiceArea.destroy({ where: {} }),
+      models.Eligibility.destroy({ where: {} }),
+      models.ServiceTaxonomySpecificAttribute.destroy({ where: {} }),
+      models.RequiredDocument.destroy({ where: {} }),
+      models.DocumentsInfo.destroy({ where: {} }),
+      models.ServiceLanguages.destroy({ where: {} }),
+      models.ServiceTaxonomy.destroy({ where: {} }),
+      models.ServiceAtLocation.destroy({ where: {} }),
+      models.PhysicalAddress.destroy({ where: {} }),
+      models.Metadata.destroy({ where: {} }),
+    ]);
+
+    await Promise.all([
+      models.Service.destroy({ where: {} }),
+      models.Location.destroy({ where: {} }),
+      models.Organization.destroy({ where: {} }),
+      models.Taxonomy.destroy({ where: {} }),
+    ]);
+  };
+
+  const createLocationFixture = async ({
+    hiddenFromSearch = false,
+    includeSecondLocation = false,
+    shareServiceAcrossLocations = false,
+  } = {}) => {
+    const organization = await models.Organization.create(
+      {
+        name: `Test Org ${Date.now()}`,
+        description: 'Organization for location deletion schedule tests.',
+        Services: [{
+          name: 'Case management',
+          Taxonomies: [{
+            name: `Taxonomy ${Date.now()}`,
+          }],
+        }],
+        Locations: [
+          {
+            name: 'Primary location',
+            description: 'Primary test location',
+            hidden_from_search: hiddenFromSearch,
+            PhysicalAddresses: [{
+              address_1: '123 Main Street',
+              city: 'New York',
+              state_province: 'NY',
+              postal_code: '10001',
+              country: 'United States',
+            }],
+          },
+          ...(includeSecondLocation ? [{
+            name: 'Secondary location',
+            description: 'Secondary test location',
+            PhysicalAddresses: [{
+              address_1: '456 Side Street',
+              city: 'New York',
+              state_province: 'NY',
+              postal_code: '10002',
+              country: 'United States',
+            }],
+          }] : []),
+        ],
+      },
+      {
+        include: [
+          {
+            model: models.Service,
+            include: [{ model: models.Taxonomy }],
+          },
+          {
+            model: models.Location,
+            include: [{ model: models.PhysicalAddress }],
+          },
+        ],
+      },
+    );
+
+    const [service] = organization.Services;
+    const [location, secondLocation] = organization.Locations;
+
+    await location.addService(service);
+    if (shareServiceAcrossLocations && secondLocation) {
+      await secondLocation.addService(service);
+    }
+
+    return {
+      organization,
+      location,
+      secondLocation,
+      service,
+    };
+  };
+
+  beforeEach(clearData);
+  afterEach(clearData);
+
+  it('schedules deletion, deletes services immediately, and hides the location', async () => {
+    const { location, service } = await createLocationFixture();
+
+    const response = await request(app)
+      .post(`/locations/${location.id}/deletion-schedule`)
+      .send({ note: 'Duplicate location entry' })
+      .expect(201);
+
+    expect(response.body.note).toBe('Duplicate location entry');
+    expect(response.body.requestedBy).toBe('<Anonymous>');
+    expect(response.body.deletedServiceCount).toBe(1);
+    expect(response.body.location.id).toBe(location.id);
+
+    const scheduledAt = new Date(response.body.scheduledForPermanentDeletionAt).getTime();
+    expect(scheduledAt).toBeGreaterThan(Date.now() + (25 * 24 * 60 * 60 * 1000));
+
+    const dbLocation = await models.Location.findByPk(location.id);
+    expect(dbLocation.hidden_from_search).toBe(true);
+
+    expect(await models.Service.findByPk(service.id)).toBeNull();
+    expect(await models.LocationDeletionSchedule.count()).toBe(1);
+
+    const locationInfo = await request(app)
+      .get(`/locations/${location.id}`)
+      .expect(200);
+    expect(locationInfo.body.Services).toHaveLength(0);
+  });
+
+  it('lists locations scheduled for deletion with the note and requester', async () => {
+    const { location } = await createLocationFixture();
+
+    await request(app)
+      .post(`/locations/${location.id}/deletion-schedule`)
+      .send({ note: 'Organization requested removal' })
+      .expect(201);
+
+    const response = await request(app)
+      .get('/locations/deletion-schedules')
+      .expect(200);
+
+    expect(response.body).toHaveLength(1);
+    expect(response.body[0]).toMatchObject({
+      note: 'Organization requested removal',
+      requestedBy: '<Anonymous>',
+      deletedServiceCount: 1,
+      location: {
+        id: location.id,
+        name: 'Primary location',
+      },
+    });
+  });
+
+  it('restores a scheduled location to its original hidden state', async () => {
+    const { location } = await createLocationFixture();
+
+    await request(app)
+      .post(`/locations/${location.id}/deletion-schedule`)
+      .send({ note: 'Needs to be reviewed before deletion' })
+      .expect(201);
+
+    await request(app)
+      .delete(`/locations/${location.id}/deletion-schedule`)
+      .expect(204);
+
+    const dbLocation = await models.Location.findByPk(location.id);
+    expect(dbLocation.hidden_from_search).toBe(false);
+    expect(await models.LocationDeletionSchedule.count()).toBe(0);
+  });
+
+  it('requires a note when scheduling a deletion', async () => {
+    const { location } = await createLocationFixture();
+
+    await request(app)
+      .post(`/locations/${location.id}/deletion-schedule`)
+      .send({})
+      .expect(400);
+  });
+
+  it('rejects scheduling deletion for a location with a shared service', async () => {
+    const { location, service } = await createLocationFixture({
+      includeSecondLocation: true,
+      shareServiceAcrossLocations: true,
+    });
+
+    const response = await request(app)
+      .post(`/locations/${location.id}/deletion-schedule`)
+      .send({ note: 'This should fail because the service is shared' })
+      .expect(400);
+
+    expect(response.body.error).toContain(sharedServiceError);
+
+    const dbLocation = await models.Location.findByPk(location.id);
+    expect(dbLocation.hidden_from_search).toBe(false);
+    expect(await models.Service.findByPk(service.id)).not.toBeNull();
+    expect(await models.LocationDeletionSchedule.count()).toBe(0);
+  });
+});

--- a/test/integration/location-deletion-schedules.test.js
+++ b/test/integration/location-deletion-schedules.test.js
@@ -105,6 +105,50 @@ describe('location deletion schedules', () => {
       await secondLocation.addService(service);
     }
 
+    await Promise.all([
+      models.DocumentsInfo.create({
+        service_id: service.id,
+        recertification_time: '30 days',
+        grace_period: '7 days',
+        additional_info: 'Bring a photo ID',
+      }),
+      models.RequiredDocument.create({
+        service_id: service.id,
+        document: 'Photo ID',
+      }),
+      models.Phone.create({
+        service_id: service.id,
+        number: '212-555-1212',
+        type: 'voice',
+        description: 'Main service line',
+      }),
+      models.RegularSchedule.create({
+        service_id: service.id,
+        weekday: 1,
+        opens_at: '09:00',
+        closes_at: '17:00',
+      }),
+      models.HolidaySchedule.create({
+        service_id: service.id,
+        closed: false,
+        opens_at: '10:00',
+        closes_at: '14:00',
+        start_date: '2026-01-01',
+        end_date: '2026-01-01',
+        occasion: 'HolidayHours',
+      }),
+      models.ServiceArea.create({
+        service_id: service.id,
+        postal_codes: ['10001', '10002'],
+        description: 'Downtown Manhattan',
+      }),
+      models.EventRelatedInfo.create({
+        service_id: service.id,
+        event: 'COVID19',
+        information: 'Masks required',
+      }),
+    ]);
+
     return {
       organization,
       location,
@@ -137,6 +181,10 @@ describe('location deletion schedules', () => {
 
     expect(await models.Service.findByPk(service.id)).toBeNull();
     expect(await models.LocationDeletionSchedule.count()).toBe(1);
+    const schedule = await models.LocationDeletionSchedule.findOne();
+    expect(schedule.service_snapshots).toHaveLength(1);
+    expect(schedule.service_snapshots[0].service.name).toBe('Case management');
+    expect(schedule.service_snapshots[0].phones).toHaveLength(1);
 
     const locationInfo = await request(app)
       .get(`/locations/${location.id}`)
@@ -183,6 +231,29 @@ describe('location deletion schedules', () => {
     const dbLocation = await models.Location.findByPk(location.id);
     expect(dbLocation.hidden_from_search).toBe(false);
     expect(await models.LocationDeletionSchedule.count()).toBe(0);
+
+    const restoredService = await models.Service.findOne({
+      include: [
+        models.Taxonomy,
+        models.DocumentsInfo,
+        models.RequiredDocument,
+        models.Phone,
+        models.RegularSchedule,
+        models.HolidaySchedule,
+        models.ServiceArea,
+        models.EventRelatedInfo,
+      ],
+    });
+    expect(restoredService.name).toBe('Case management');
+    expect(restoredService.additional_info).toBeNull();
+    expect(restoredService.Taxonomies).toHaveLength(1);
+    expect(restoredService.DocumentsInfo.recertification_time).toBe('30 days');
+    expect(restoredService.RequiredDocuments[0].document).toBe('Photo ID');
+    expect(restoredService.Phones[0].number).toBe('212-555-1212');
+    expect(restoredService.RegularSchedules[0].opens_at).toBe('09:00:00');
+    expect(restoredService.HolidaySchedules[0].occasion).toBe('HolidayHours');
+    expect(restoredService.ServiceAreas[0].postal_codes).toEqual(['10001', '10002']);
+    expect(restoredService.EventRelatedInfos[0].information).toBe('Masks required');
   });
 
   it('requires a note when scheduling a deletion', async () => {


### PR DESCRIPTION
## Summary
- add location deletion scheduling support, including schedule model, migrations, validation, and route wiring
- snapshot and restore service state for scheduled location deletion flows
- add Slack notification support and coverage for location deletion schedules

## Impact
This gives Streetlives a deployable backend path for scheduling location deletions while preserving enough service snapshot data to restore state when needed.

## Validation
- Not rerun in this session; PR was opened from the already-pushed `feature/location-scheduled-deletion` branch.