### PR TITLE
Fix 'more than one row returned by a subquery' on neighborhood lookup

### DIFF
--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -78,6 +78,7 @@ const getNeighborhoodAttributeSubquery = {
               nyc_neighborhood_geometries.geometry,
               ST_SetSRID(position,4326)
             )
+            LIMIT 1
         )`),
         'neighborhood',
       ],


### PR DESCRIPTION
The neighborhood scalar subquery in getNeighborhoodAttributeSubquery could return multiple rows when nyc_neighborhood_geometries contains duplicate geometries (as in staging), causing /location-by-slug and /locations/:locationId to fail. Add LIMIT 1 so a single row is always returned.