### PR TITLE
Exclude closed locations from search

### DIFF
--- a/src/models/location.js
+++ b/src/models/location.js
@@ -67,12 +67,16 @@ module.exports = (sequelize, DataTypes, Op) => {
     IS_CLOSED_COLUMN_ALIAS,
   ];
 
-  // Excludes locations whose CLOSURE event was recorded more than MAX_CLOSED_AGE_INTERVAL ago.
+  // Excludes locations whose *latest* CLOSURE event was recorded more than
+  // MAX_CLOSED_AGE_INTERVAL ago. Keyed off MAX(created_at) so a location with an old closure
+  // record plus a newer one is treated as recently closed (kept) rather than long-closed. The
+  // aggregate subquery yields no rows when the location has no closures (MAX is NULL, so the
+  // HAVING is not satisfied), so non-closed locations are always kept.
   const CLOSED_TOO_LONG_EXCLUSION = sequelize.literal(`NOT EXISTS (
                 SELECT 1 FROM event_related_info eri
                 WHERE eri.location_id = "Location"."id"
                   AND eri.event = '${CLOSURE_EVENT_TYPE}'
-                  AND eri.created_at < now() - interval '${MAX_CLOSED_AGE_INTERVAL}'
+                HAVING MAX(eri.created_at) < now() - interval '${MAX_CLOSED_AGE_INTERVAL}'
             )`);
 
   Location.associate = (models) => {

--- a/src/models/location.js
+++ b/src/models/location.js
@@ -697,8 +697,14 @@ module.exports = (sequelize, DataTypes, Op) => {
     const allResults = (await Promise.all(queryPromises)).flat();
 
     // Apply sorting in memory
+    // For a text search, findUniqueLocationIds already produced the final order (search
+    // relevance, then the requested sort, then closed locations pushed to the bottom), so we
+    // must preserve that order here. Re-sorting by the requested attribute below would move
+    // closed locations back up when an explicit sort (e.g. nearby, most services) is combined
+    // with a search string, so it is only applied when there is no search string.
+    const isTextSearch = !!filterParameters.searchString;
     let sortedLocationsWithAssociations;
-    if (order) {
+    if (order && !isTextSearch) {
       // Sort by the specified order attribute (e.g., distance, service_count, last_validated_at)
       const [sortAttr, sortDir] = order[0]; // Assuming single-level order
       sortedLocationsWithAssociations = allResults.sort((a, b) => {
@@ -711,8 +717,8 @@ module.exports = (sequelize, DataTypes, Op) => {
         }
       });
     } else {
-      // For text search, findUniqueLocationIds already sorts closed locations to the bottom;
-      // preserving the locationIds order here keeps them there.
+      // Preserve the locationIds order (which keeps closed locations at the bottom for a
+      // text search).
       sortedLocationsWithAssociations = allResults.sort(sortByLocationIds);
     }
 

--- a/src/models/location.js
+++ b/src/models/location.js
@@ -49,6 +49,32 @@ module.exports = (sequelize, DataTypes, Op) => {
     SERVICE_COUNT_COLUMN_ALIAS,
   ];
 
+  const CLOSURE_EVENT_TYPE = 'CLOSURE';
+  // A location is considered closed while it has a CLOSURE event. Closures older than
+  // this are dropped from search results entirely; more recent ones are kept but sorted
+  // to the bottom of the results.
+  const MAX_CLOSED_AGE_INTERVAL = '3 months';
+
+  const IS_CLOSED_COLUMN_ALIAS = 'is_closed';
+  const IS_CLOSED_SUBQUERY = [
+    sequelize.literal(`(
+                EXISTS (
+                  SELECT 1 FROM event_related_info eri
+                  WHERE eri.location_id = "Location"."id"
+                    AND eri.event = '${CLOSURE_EVENT_TYPE}'
+                )
+            )`),
+    IS_CLOSED_COLUMN_ALIAS,
+  ];
+
+  // Excludes locations whose CLOSURE event was recorded more than MAX_CLOSED_AGE_INTERVAL ago.
+  const CLOSED_TOO_LONG_EXCLUSION = sequelize.literal(`NOT EXISTS (
+                SELECT 1 FROM event_related_info eri
+                WHERE eri.location_id = "Location"."id"
+                  AND eri.event = '${CLOSURE_EVENT_TYPE}'
+                  AND eri.created_at < now() - interval '${MAX_CLOSED_AGE_INTERVAL}'
+            )`);
+
   Location.associate = (models) => {
     Location.belongsTo(models.Organization, { foreignKey: 'organization_id' });
     Location.belongsToMany(models.Service, {
@@ -350,6 +376,11 @@ module.exports = (sequelize, DataTypes, Op) => {
     if (occasion) {
       whereConditions.push(getOccasionCondition(occasion));
     }
+    // For text search only: drop locations closed for longer than MAX_CLOSED_AGE_INTERVAL,
+    // and (further below) sort the remaining closed locations to the bottom of the results.
+    if (searchString) {
+      whereConditions.push(sequelize.where(CLOSED_TOO_LONG_EXCLUSION, true));
+    }
 
     // we put empty object in the having array to work around this bug in sequelize:
     // https://github.com/sequelize/sequelize/issues/10142
@@ -382,6 +413,8 @@ module.exports = (sequelize, DataTypes, Op) => {
           sequelize.fn('DISTINCT', sequelize.col('Location.id')),
           // For SELECT DISTINCT, ORDER BY expressions must appear in select list.
           ...(selectedAttributeForOrderBy ? [selectedAttributeForOrderBy] : []),
+          // For text search only: used to push closed locations to the bottom (see below).
+          ...(searchString ? [IS_CLOSED_SUBQUERY] : []),
         ],
         raw: true,
         // Not like associations and grouping work perfectly out of the box either though...
@@ -509,6 +542,17 @@ module.exports = (sequelize, DataTypes, Op) => {
       locations = orderedLocations;
     } else {
       locations = await findAll(whereConditions);
+    }
+
+    // For text search only: closed (but not yet expired) locations always sort to the bottom
+    // of the results. This is a stable partition, so the relative order within each group is
+    // preserved. Applied before pagination so closed locations land on the final pages rather
+    // than being interleaved.
+    if (searchString) {
+      locations = [
+        ...locations.filter(location => !location[IS_CLOSED_COLUMN_ALIAS]),
+        ...locations.filter(location => location[IS_CLOSED_COLUMN_ALIAS]),
+      ];
     }
 
     // apply limit and offset in memory here
@@ -667,7 +711,8 @@ module.exports = (sequelize, DataTypes, Op) => {
         }
       });
     } else {
-      // Sort by locationIds order
+      // For text search, findUniqueLocationIds already sorts closed locations to the bottom;
+      // preserving the locationIds order here keeps them there.
       sortedLocationsWithAssociations = allResults.sort(sortByLocationIds);
     }
 

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -1163,4 +1163,89 @@ describe('find locations', () => {
       expect(primary.closed).toBe(true);
     });
   });
+
+  describe('closed locations in search results', () => {
+    afterEach(() => models.EventRelatedInfo.destroy({ where: {} }));
+
+    const markClosed = async (location, { closedAgoMs = 0 } = {}) => {
+      const closure = await models.EventRelatedInfo.create({
+        event: 'CLOSURE',
+        information: 'Location is closed',
+        location_id: location.id,
+      });
+
+      if (closedAgoMs) {
+        await models.sequelize.query(
+          'UPDATE event_related_info SET created_at = :createdAt WHERE id = :id',
+          { replacements: { createdAt: new Date(Date.now() - closedAgoMs), id: closure.id } },
+        );
+      }
+
+      return closure;
+    };
+
+    const FOUR_MONTHS_MS = 4 * 30 * 24 * 60 * 60 * 1000;
+
+    const expectClosedLastForTextSearch = (res, closedLocation) => {
+      const closed = res.body.find(l => l.name === closedLocation.name);
+      expect(closed).toBeDefined();
+      expect(closed.closed).toBe(true);
+
+      // The closed location must come after every open (non-closed) location.
+      const lastOpenIndex = res.body.reduce(
+        (acc, location, index) => (location.closed ? acc : index),
+        -1,
+      );
+      const closedIndex = res.body.findIndex(l => l.name === closedLocation.name);
+      expect(closedIndex).toBeGreaterThan(lastOpenIndex);
+    };
+
+    it('should exclude long-closed locations from a text search', async () => {
+      await markClosed(primaryLocation, { closedAgoMs: FOUR_MONTHS_MS });
+
+      const res = await request(app)
+        .get('/locations')
+        .query({ searchString: 'center' })
+        .expect(200);
+
+      expect(res.body).not.toContainEqual(expect.objectContaining({ name: primaryLocation.name }));
+      expect(res.body).toContainEqual(expect.objectContaining({ name: otherServiceLocation.name }));
+    });
+
+    it('should sort recently closed locations to the bottom for a text search', async () => {
+      await markClosed(primaryLocation);
+
+      const res = await request(app)
+        .get('/locations')
+        .query({ searchString: 'center' })
+        .expect(200);
+
+      expectClosedLastForTextSearch(res, primaryLocation);
+    });
+
+    it('should sort closed locations to the bottom for a paginated text search', async () => {
+      await markClosed(primaryLocation);
+
+      const res = await request(app)
+        .get('/locations')
+        .query({ searchString: 'center', pageNumber: 0, pageSize: 10 })
+        .expect(200);
+
+      expectClosedLastForTextSearch(res, primaryLocation);
+    });
+
+    it('should NOT exclude or reorder closed locations when not text searching', async () => {
+      await markClosed(primaryLocation, { closedAgoMs: FOUR_MONTHS_MS });
+
+      const res = await request(app)
+        .get('/locations')
+        .query({ organizationName: 'test org' })
+        .expect(200);
+
+      // Browsing (no searchString) is unaffected: the long-closed location is still returned.
+      const primary = res.body.find(l => l.name === primaryLocation.name);
+      expect(primary).toBeDefined();
+      expect(primary.closed).toBe(true);
+    });
+  });
 });

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -1234,6 +1234,38 @@ describe('find locations', () => {
       expectClosedLastForTextSearch(res, primaryLocation);
     });
 
+    it('should keep closed locations last for a nearby-sorted text search', async () => {
+      // primaryLocation is the closest to the origin, so a nearby sort would normally rank it
+      // first; closing it must instead push it to the bottom of the results.
+      await markClosed(primaryLocation);
+
+      const res = await request(app)
+        .get('/locations')
+        .query({
+          searchString: 'center',
+          sortBy: 'nearby',
+          latitude: originLatitude,
+          longitude: originLongitude,
+        })
+        .expect(200);
+
+      expectClosedLastForTextSearch(res, primaryLocation);
+    });
+
+    it('should keep closed locations last for a most-services-sorted text search', async () => {
+      // Give primaryLocation the most services so a mostServices sort would normally rank it
+      // first; closing it must instead push it to the bottom of the results.
+      await primaryLocation.addServices([aSpecificOffering2, aDifferentKindOfService]);
+      await markClosed(primaryLocation);
+
+      const res = await request(app)
+        .get('/locations')
+        .query({ searchString: 'center', sortBy: 'mostServices' })
+        .expect(200);
+
+      expectClosedLastForTextSearch(res, primaryLocation);
+    });
+
     it('should NOT exclude or reorder closed locations when not text searching', async () => {
       await markClosed(primaryLocation, { closedAgoMs: FOUR_MONTHS_MS });
 

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -1185,6 +1185,7 @@ describe('find locations', () => {
     };
 
     const FOUR_MONTHS_MS = 4 * 30 * 24 * 60 * 60 * 1000;
+    const FIVE_MONTHS_MS = 5 * 30 * 24 * 60 * 60 * 1000;
 
     const expectClosedLastForTextSearch = (res, closedLocation) => {
       const closed = res.body.find(l => l.name === closedLocation.name);
@@ -1202,6 +1203,33 @@ describe('find locations', () => {
 
     it('should exclude long-closed locations from a text search', async () => {
       await markClosed(primaryLocation, { closedAgoMs: FOUR_MONTHS_MS });
+
+      const res = await request(app)
+        .get('/locations')
+        .query({ searchString: 'center' })
+        .expect(200);
+
+      expect(res.body).not.toContainEqual(expect.objectContaining({ name: primaryLocation.name }));
+      expect(res.body).toContainEqual(expect.objectContaining({ name: otherServiceLocation.name }));
+    });
+
+    it('should keep a location whose latest closure is recent despite an older one', async () => {
+      // An old closure plus a newer one: the location was re-closed recently, so it must be
+      // treated as recently closed (kept, sorted last) rather than long-closed (excluded).
+      await markClosed(primaryLocation, { closedAgoMs: FIVE_MONTHS_MS });
+      await markClosed(primaryLocation);
+
+      const res = await request(app)
+        .get('/locations')
+        .query({ searchString: 'center' })
+        .expect(200);
+
+      expectClosedLastForTextSearch(res, primaryLocation);
+    });
+
+    it('should exclude a location when every closure is older than 3 months', async () => {
+      await markClosed(primaryLocation, { closedAgoMs: FOUR_MONTHS_MS });
+      await markClosed(primaryLocation, { closedAgoMs: FIVE_MONTHS_MS });
 
       const res = await request(app)
         .get('/locations')

--- a/test/integration/find-locations.test.js
+++ b/test/integration/find-locations.test.js
@@ -1262,6 +1262,32 @@ describe('find locations', () => {
       expectClosedLastForTextSearch(res, primaryLocation);
     });
 
+    it('should move recently closed locations to a later page than open matches', async () => {
+      // 'center' matches three locations (primary, other, far). Closing one leaves two open,
+      // so with a page size of 2 the closed location can only appear on the first page if it
+      // is partitioned *after* pagination. It should instead be pushed to the second page.
+      await markClosed(primaryLocation);
+
+      const firstPage = await request(app)
+        .get('/locations')
+        .query({ searchString: 'center', pageNumber: 0, pageSize: 2 })
+        .expect(200);
+
+      expect(firstPage.headers['total-count']).toBe('3');
+      expect(firstPage.body).toHaveLength(2);
+      expect(firstPage.body.some(l => l.closed)).toBe(false);
+      expect(firstPage.body.map(l => l.name)).not.toContain(primaryLocation.name);
+
+      const secondPage = await request(app)
+        .get('/locations')
+        .query({ searchString: 'center', pageNumber: 1, pageSize: 2 })
+        .expect(200);
+
+      const closedOnSecondPage = secondPage.body.find(l => l.name === primaryLocation.name);
+      expect(closedOnSecondPage).toBeDefined();
+      expect(closedOnSecondPage.closed).toBe(true);
+    });
+
     it('should keep closed locations last for a nearby-sorted text search', async () => {
       // primaryLocation is the closest to the origin, so a nearby sort would normally rank it
       // first; closing it must instead push it to the bottom of the results.


### PR DESCRIPTION
When a search string is present, exclude locations whose CLOSURE event is older than 3 months, and sort the remaining closed locations to the bottom of the results. Browsing (no searchString) is unaffected.