### PR TITLE
Fix: mark location closed from COVID19 note alone on prod (parity with #185)

### DIFF
--- a/src/controllers/locations.js
+++ b/src/controllers/locations.js
@@ -21,10 +21,7 @@ const isLocationClosed = (occasion, eventRelatedInfos, services) => {
   }
   const hasCOVIDEventRelatedInfo = eventRelatedInfos &&
   eventRelatedInfos.some(eventRelatedInfo => eventRelatedInfo.event === occasion);
-  const locationServicesAllClosed = !services ||
-  services.every(service => service.HolidaySchedules.every(holidaySchedule =>
-    holidaySchedule.closed));
-  return hasCOVIDEventRelatedInfo && locationServicesAllClosed;
+  return hasCOVIDEventRelatedInfo;
 };
 
 const getInfoAssociations = {


### PR DESCRIPTION
## Problem

Closing a location silently fails on production — in **both** the native GoGetta web app and the browser extension. The closure message saves, the UI redirects to `/team` as if it succeeded, but the location's `closed` flag never flips.

## Root cause — a deploy skew

`closed` is computed by `isLocationClosed`. On the prod line (`tactical-fix-for-prod`) it still requires **both** a COVID19 closure note **and** all services' holiday schedules closed:

```js
return hasCOVIDEventRelatedInfo && locationServicesAllClosed;
```

- streetlives-web PR **#323** (commit `af9e142`, 2026-03-11, "Don't reset hours after closing locations") removed the `markClosed` step that used to close every service, on the assumption the API marks a location closed from the **note alone**.
- That API relaxation — **#185** (`53f2993`, "Update closed locations condition") — landed on `develop`/test on 2026-03-13 but **was never promoted to prod**.
- The extension's close path (`submitLocationClosure`) likewise writes only the note.

So since ~**2026-03-11**, both clients write the COVID19 note but no longer close services → `allServicesClosed` is false → `closed` stays false.

### Confirmed live on prod
`GET /prod/locations/d136ffc7-1d56-4e95-bc3e-65c66f5dcec3` — COVID19 note *"This location is indefinitely closed"*, 10 services open, `closed: false`.

## Fix

Port #185 to the prod line: derive `closed` from the presence of the COVID19 closure note (what both clients now write). Reopen (`markOpen`) already deletes the note, so the close/reopen signal stays symmetric. This diff is byte-identical to #185.

## ⚠️ Rollout caveat — read before deploying

Note-only `closed` also flips **any** location carrying a lingering legacy COVID19 note (places that reopened without the note being cleared). Before/with deploy, audit the data. Query to list locations that currently have a COVID19 note but are **not** actually closed (i.e., will flip), split by whether the note predates the bug window:

```sql
WITH covid_notes AS (
  SELECT eri.location_id,
         MAX(eri.created_at) AS note_created_at
  FROM event_related_info eri
  WHERE eri.event = 'COVID19'
    AND COALESCE(eri.information, '') <> ''
  GROUP BY eri.location_id
),
open_service_hours AS (          -- locations with >=1 OPEN holiday schedule => currently closed=false
  SELECT DISTINCT sal.location_id
  FROM holiday_schedules hs
  JOIN service_at_locations sal ON sal.service_id = hs.service_id
  WHERE hs.closed = false
)
SELECT
  CASE WHEN cn.note_created_at >= TIMESTAMP '2026-03-11'
       THEN 'POST 2026-03-11 (bug window - failed closures)'
       ELSE 'PRE 2026-03-11 (legacy - review for stale notes)' END AS period,
  cn.note_created_at,
  'https://gogetta.nyc/team/location/' || cn.location_id AS gogetta_url
FROM covid_notes cn
JOIN open_service_hours oh ON oh.location_id = cn.location_id
ORDER BY (cn.note_created_at >= TIMESTAMP '2026-03-11') DESC, cn.note_created_at DESC;
```

## Refs
- API relaxation that never reached prod: #185 (`53f2993`)
- Web change that assumed it: streetlives-web #323 (`af9e142`)

Alternative if you'd rather not change prod `closed` semantics: revert the web `markClosed` removal (and mark services closed in the extension) so both clients close services again — but that reintroduces the "reset hours" behavior #323 was fixing.
